### PR TITLE
update pip-url for aiida-vasp (after release on PyPi)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -32,7 +32,7 @@
         "state": "development",
         "code_home": "https://github.com/DropD/aiida-vasp/tree/develop",
         "plugin_info": "https://raw.githubusercontent.com/DropD/aiida-vasp/develop/setup.json",
-        "pip_url": "git+https://github.com/DropD/aiida-vasp/tree/master#egg=aiida-vasp-0.1.1",
+        "pip_url": "aiida-vasp",
         "documentation_url": "http://aiida-vasp.readthedocs.io/"
     },
     "cp2k": {


### PR DESCRIPTION
closes DropD/aiida-vasp#114