### PR TITLE
Updated link to aiida-vasp due to change to organization

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -30,8 +30,8 @@
         "name": "aiida-vasp",
         "entry_point": "vasp",
         "state": "development",
-        "code_home": "https://github.com/aiidateam/aiida-vasp",
-        "plugin_info": "https://raw.githubusercontent.com/aiidateam/aiida-vasp/develop/setup.json",
+        "code_home": "https://github.com/aiida-vasp/aiida-vasp",
+        "plugin_info": "https://raw.githubusercontent.com/aiida-vasp/aiida-vasp/develop/setup.json",
         "pip_url": "aiida-vasp",
         "documentation_url": "http://aiida-vasp.readthedocs.io/"
     },


### PR DESCRIPTION
Done in order to comply with the recent change to organization for the development of the VASP plugin.