### PR TITLE
Update pip_url in Siesta's record in plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -62,7 +62,7 @@
         "name": "aiida-siesta",
         "entry_point": "siesta",
         "state": "development",
-        "pip_url": "git+https://github.com/vdikan/aiida_siesta_plugin/#egg=aiida-siesta-0.9.7",
+        "pip_url": "git+https://github.com/albgar/aiida_siesta_plugin",
         "plugin_info": "https://raw.github.com/albgar/aiida_siesta_plugin/master/setup.json",
         "code_home": "https://github.com/albgar/aiida_siesta_plugin/tree/master",
         "documentation_url": "http://aiida-siesta-plugin.readthedocs.io/"


### PR DESCRIPTION
Hi,

I have removed the reference to Vladimir's repo, to simplify maintenance. Also, I removed the explicit "#egg..." spec to avoid having to update the plugins.json file after each upgrade in the repo.
