### PR TITLE
Add new in development `aiida-tcod` plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -262,5 +262,14 @@
         "code_home": "https://github.com/greschd/aiida-tbextraction",
         "documentation_url": "https://aiida-tbextraction.readthedocs.io/",
         "pip_url": "aiida-tbextraction"
+    },
+    "tcod": {
+        "name": "aiida-tcod",
+        "entry_point": "tcod",
+        "state": "development",
+        "pip_url": "git+https://github.com/aiidateam/aiida-tcod",
+        "plugin_info": "https://raw.github.com/aiidateam/aiida-tcod/master/setup.json",
+        "code_home": "https://github.com/aiidateam/aiida-tcod",
+        "documentation_url": "http://aiida-tcod.readthedocs.io/"
     }
 }


### PR DESCRIPTION
The initial code has been migrated from the `aiida-core` package where
it was being developed until `v1.0.0b1`