### PR TITLE
fix package name for aiida-core

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,7 @@
 {
     "core": {
         "name": "aiida-core",
-        "package_name": "aiida_core",
+        "package_name": "aiida",
         "entry_point": "",
         "state": "stable",
         "pip_url": "git+https://github.com/aiidateam/aiida-core",


### PR DESCRIPTION
package_name determines instructions on how to import, i.e. it should be
"aiida", not "aiida_core"