### PR TITLE
add plugin state dev tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ community of your ongoing work.
     "new": {
         "name": "aiida-new",
         "entry_point": "new",
-        "state": "development",
+        "state": "registered",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-new/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-new",
         "documentation_url": "http://aiida-new.readthedocs.io/"
@@ -41,9 +41,9 @@ The name which is at the beginning of all entry points exposed by the plugin
 
 #### state
 One of
-* `registered`: designates plugins which are not in a working state and may or may not have any code written. Use this to secure a specific name
-* `development`: plugins which work partially but may not be stable yet
-* `stable`: plugins which can be used in production. 
+* `registered`: plugin is not yet in a working state. Use this to secure a specific name before starting development
+* `development`: plugin adds new functionality but isn't stable enough for production use
+* `stable`: plugin can be used in production
 
 #### pip_url
 A url that can be used to directly install the most recent ('development') or most recent stable ('stable') version with pip.

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -83,6 +83,14 @@ entrypoint_metainfo = {
     },
 }
 
+# User-facing description of plugin development states
+state_dict = {
+    'registered': "Not yet usable, developers welcome.",
+    'development':
+    "Adds some functionality but not ready for prime-time. Testing welcome.",
+    'stable': "Ready for production calculations. Bug reports welcome.",
+}
+
 ## dictionary of human-readable entrypointtypes
 entrypointtypes = {k: v['longname'] for k, v in entrypoint_metainfo.items()}
 
@@ -264,6 +272,11 @@ def complete_plugin_data(plugin_data, subpage_name):
         'entrypointtypes'] = entrypointtypes  # add a static entrypointtypes dictionary
     plugin_data['summaryinfo'] = get_summary_info(plugin_data['setup_json'])
     plugin_data['aiida_version'] = get_aiida_version(plugin_data['setup_json'])
+
+    plugin_data['state_dict'] = state_dict
+    # note: for more validation, it might be sensible to switch to voluptuous
+    if plugin_data['state'] not in list(state_dict.keys()):
+        print("  >> WARNING: Invalid state {}".format(plugin_data['state']))
 
     return plugin_data
 

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -85,10 +85,10 @@ entrypoint_metainfo = {
 
 # User-facing description of plugin development states
 state_dict = {
-    'registered': "Not yet usable, developers welcome.",
+    'registered': "Not yet ready to use. Developers welcome!",
     'development':
-    "Adds some functionality but not ready for prime-time. Testing welcome.",
-    'stable': "Ready for production calculations. Bug reports welcome.",
+    "Adds new functionality, not yet ready for production. Testing welcome!",
+    'stable': "Ready for production calculations. Bug reports welcome!",
 }
 
 ## dictionary of human-readable entrypointtypes

--- a/make_ghpages/mod/templates/main_index.html
+++ b/make_ghpages/mod/templates/main_index.html
@@ -32,7 +32,12 @@
         {% if plugin.setup_json.description %}
         <p class=description>{{plugin.setup_json.description}}</p>
         {% endif %}
-        <p class="currentstate">Current state: {{ plugin.state }}
+        <p class="currentstate">Current state:
+            <span class="classbox">{{  plugin.state }}
+                <span class="tooltiptext">
+                    {{ plugin.state_dict[plugin.state] }}
+                </span>
+            </span>
             {%- if plugin.aiida_version -%}
             <span class=aiida_version>, compatible with aiida-core{{plugin.aiida_version}}</span>
             {%- endif -%}    

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -15,7 +15,12 @@
     <h2>General information</h2>
     <div>
         <p>
-            Current state: <emph>{{ state }}</emph>
+            Current state:
+            <span class="classbox">{{  state }}
+                <span class="tooltiptext">
+                    {{ state_dict[state] }}
+                </span>
+            </span>
         </p>
 
         <p>
@@ -85,7 +90,7 @@
                 <li><code>{{ entrypoint.split('=')[0].strip() }}</code>
                     <div class="classbox">class<span class="tooltiptext">
                         {{ entrypoint.split('=')[1].strip() }}
-                    </span></li>
+                    </span></div></li>
                 {% endfor %}
                 </ul>
             {% endfor %}

--- a/make_ghpages/requirements.txt
+++ b/make_ghpages/requirements.txt
@@ -6,3 +6,5 @@ yapf==0.27.0
 prospector==0.12.11
 pylint==1.9.4
 requirements-parser==0.2.0
+requests
+requests-cache

--- a/plugins.json
+++ b/plugins.json
@@ -1,4 +1,14 @@
 {
+    "core": {
+        "name": "aiida-core",
+        "package_name": "aiida_core",
+        "entry_point": "",
+        "state": "stable",
+        "pip_url": "git+https://github.com/aiidateam/aiida-core",
+        "plugin_info": "https://raw.githubusercontent.com/aiidateam/aiida-core/v1.0.0b6/setup.json",
+        "code_home": "https://github.com/aiidateam/aiida-core",
+        "documentation_url": "http://aiida-core.readthedocs.io/"
+    },
     "quantumespresso": {
         "name": "aiida-quantumespresso",
         "entry_point": "quantumespresso",

--- a/plugins.json
+++ b/plugins.json
@@ -30,7 +30,7 @@
     "diff": {
         "name": "aiida-diff",
         "entry_point": "diff",
-        "state": "development",
+        "state": "stable",
         "pip_url": "git+https://github.com/aiidateam/aiida-diff#egg=aiida-diff-0.1.0a0",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-diff/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-diff",
@@ -48,7 +48,7 @@
     "alloy":{
         "name": "aiida-alloy",
         "entry_point": "alloy",
-        "state": "development",
+        "state": "registered",
         "code_home": "https://github.com/DanielMarchand/aiida-alloy",
         "plugin_info": "https://raw.githubusercontent.com/DanielMarchand/aiida-alloy/master/setup.json",
         "pip_url": "aiida-alloy"
@@ -153,7 +153,7 @@
     "zeopp": {
         "name": "aiida-zeopp",
         "entry_point": "zeopp",
-        "state": "development",
+        "state": "stable",
         "plugin_info": "https://raw.github.com/ltalirz/aiida-zeopp/master/setup.json",
         "code_home": "https://github.com/ltalirz/aiida-zeopp"
     },
@@ -224,7 +224,7 @@
     "qeq": {
         "name": "aiida-qeq",
         "entry_point": "qeq",
-        "state": "development",
+        "state": "stable",
         "plugin_info": "https://raw.githubusercontent.com/ltalirz/aiida-qeq/master/setup.json",
         "code_home": "http://github.com/ltalirz/aiida-qeq"
     },
@@ -303,7 +303,7 @@
     "uppasd": {
         "name": "aiida-uppasd",
         "entry_point": "uppasd",
-        "state": "development",
+        "state": "registered",
         "pip_url": "aiida-uppasd",
         "plugin_info": "https://raw.github.com/uppasd/aiida-uppasd/master/setup.json",
         "code_home": "https://github.com/uppasd/aiida-uppasd",
@@ -312,7 +312,7 @@
     "hea":{
         "name": "aiida-hea",
         "entry_point": "hea",
-        "state": "development",
+        "state": "registered",
         "code_home": "https://github.com/unkcpz/aiida-hea",
         "plugin_info": "https://raw.github.com/unkcpz/aiida-hea/master/setup.json",
         "pip_url": "aiida-hea",


### PR DESCRIPTION
 * add tooltips for plugin state development
 * switch registration instructions from "development" to "registered"
   status
 * downgrade some plugins from "development" to "registered" that still had "Diff" stuff in them
 * upgrade some of my plugins to "stable" that are being used in production