### PR TITLE
fix pip_urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,18 @@ env:
   - ENCRYPTION_LABEL: "7712d5cd71ad"
   - COMMIT_AUTHOR_EMAIL: deploy@travis-ci.org
 
+matrix:
+  include:
+  - name: Build HTML
+    env:
+    - JOB: HTML
+  - name: Install plugins
+    env:
+    - JOB: INSTALL
+
+  allow_failures:
+  - name: Install plugins
+
 before_install:
   # This is needed for the SSH tests (being able to ssh to localhost)
   # And will also be used for the docker test
@@ -20,9 +32,8 @@ install:
   - pip install -r requirements.txt
 
 script: 
-  - ./make_pages.py  
-  - ./test_install.py
-  - cd ../.travis-data && ./deploy.sh
+  - if [ "$JOB" == "HTML" ]; then ./make_pages.py; cd ../.travis-data && ./deploy.sh; fi
+  - if [ "$JOB" == "INSTALL" ]; then ./test_install.py; fi
 
 ## See docs here: https://docs.travis-ci.com/user/deployment/pages/
 ## This works, but we're not using it to avoid to have global tokens.

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ install:
 
 script: 
   - ./make_pages.py  
+  - ./test_install.py
   - cd ../.travis-data && ./deploy.sh
 
 ## See docs here: https://docs.travis-ci.com/user/deployment/pages/

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ community of your ongoing work.
 ## How to register a plugin
 
 1. Fork the repository
-2. Add your plugin to the `plugins.json` file, e.g. 
+2. Add your plugin to the `plugins.json` file, e.g.
     ```
     "new": {
         "name": "aiida-new",
@@ -46,7 +46,11 @@ One of
 * `stable`: plugin can be used in production
 
 #### pip_url
-A url that can be used to directly install the most recent ('development') or most recent stable ('stable') version with pip.
+A URL or PyPI package name for installing the most recent development (`state: 'development'`) or stable (`state: 'stable'`) version of the package with pip.
+
+Examples:
+ * `"pip_url": "aiida-quantumespresso"` for a package that is [registered on PyPI](https://pypi.org/project/aiida-quantumespresso/)
+ * `"pip_url": "git+https://github.com/aiidateam/aiida-wannier90"` for a package not registered on PyPI
 
 #### plugin_info
 A URL pointing to a JSON file which holds all keyword args, as given to the setuptools.setup function at install.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ community of your ongoing work.
 
 ## How to register a plugin
 
-1. Fork the repository
+1. Fork this repository
 2. Add your plugin to the `plugins.json` file, e.g.
     ```
     "new": {
@@ -47,11 +47,12 @@ One of
 
 #### pip_url
 A URL or PyPI package name for installing the most recent development (`state: 'development'`) or stable (`state: 'stable'`) version of the package with pip.
+Expected for states `development` and `stable`.
 
 Examples:
  * `"pip_url": "aiida-quantumespresso"` for a package that is [registered on PyPI](https://pypi.org/project/aiida-quantumespresso/)
  * `"pip_url": "git+https://github.com/aiidateam/aiida-wannier90"` for a package not registered on PyPI
-
+ 
 #### plugin_info
 A URL pointing to a JSON file which holds all keyword args, as given to the setuptools.setup function at install.
 See, for example, the [aiida-plugin-template repository](http://github.com/aiidateam/aiida-plugin-template).

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -30,6 +30,7 @@ OUT_FOLDER = 'out'
 STATIC_FOLDER = 'static'
 HTML_FOLDER = 'plugins'  # Name for subfolder where HTMLs for plugins are going to be sitting
 TEMPLATES_FOLDER = 'templates'
+DATA_JSON = 'all_data.json'
 
 # Absolute paths
 pwd = os.path.split(os.path.abspath(__file__))[0]
@@ -361,3 +362,7 @@ if __name__ == "__main__":
     with codecs.open(outfile, 'w', 'utf-8') as f:
         f.write(rendered)
     print("  - index.html generated")
+
+    with open(DATA_JSON, 'w') as handle:
+        json.dump(all_data, handle, indent=2)
+    print("  - {} dumped".format(DATA_JSON))

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -263,7 +263,7 @@ def complete_plugin_data(plugin_data, subpage_name):
     else:
         plugin_data['setup_json'] = get_setup_json(setup_json_link)
         if plugin_data['setup_json'] and 'package_name' not in list(
-                plugin_data['setup_json'].keys()):
+                plugin_data.keys()):
             plugin_data['setup_json']['package_name'] = plugin_data[
                 'setup_json']['name'].replace('-', '_')
 

--- a/make_ghpages/make_pages.py
+++ b/make_ghpages/make_pages.py
@@ -262,10 +262,9 @@ def complete_plugin_data(plugin_data, subpage_name):
         plugin_data['setup_json'] = None
     else:
         plugin_data['setup_json'] = get_setup_json(setup_json_link)
-        if plugin_data['setup_json'] and 'package_name' not in list(
-                plugin_data.keys()):
-            plugin_data['setup_json']['package_name'] = plugin_data[
-                'setup_json']['name'].replace('-', '_')
+
+        if 'package_name' not in list(plugin_data.keys()):
+            plugin_data['package_name'] = plugin_data['name'].replace('-', '_')
 
     plugin_data['subpage'] = subpage_name
     plugin_data['hosted_on'] = get_hosted_on(plugin_data['code_home'])

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -50,9 +50,11 @@
         <p>
             <strong>Short description</strong>: {{ setup_json.description }}
         </p>
+        {%  if pip_url %}
         <p>
-            <strong>Package name (for pip)</strong>: <code>{{ name }}</code>
+            <strong>How to install</strong>: <code>pip install {{ pip_url }}</code>
         </p>
+        {% endif %}
         <p>
             <strong>How to use from python</strong>: <code>import {{ setup_json.package_name }}</code>
         </p>

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -56,7 +56,7 @@
         </p>
         {% endif %}
         <p>
-            <strong>How to use from python</strong>: <code>import {{ setup_json.package_name }}</code>
+            <strong>How to use from python</strong>: <code>import {{ package_name }}</code>
         </p>
         <p>
             <strong>Most recent version</strong>: {{ setup_json.version }}

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -38,10 +38,10 @@ if __name__ == "__main__":
             continue
 
         if 'pip_url' not in list(v.keys()):
-            print("  >> WARNING: Missing pip_url key!")
+            print("    >> WARNING: Missing pip_url key!")
             continue
 
-        print(" - Installing {}".format(v['name']))
+        print("   - Installing {}".format(v['name']))
         is_installed = try_cmd("pip install {}".format(v['pip_url']))
 
         if not is_installed:
@@ -50,5 +50,5 @@ if __name__ == "__main__":
         if 'package_name' not in list(v.keys()):
             v['package_name'] = v['name'].replace('-', '_')
 
-        print(" - Importing {}".format(v['package_name']))
+        print("   - Importing {}".format(v['package_name']))
         try_cmd("python -c 'import {}'".format(v['package_name']))

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -30,4 +30,5 @@ if __name__ == "__main__":
         try_cmd("pip install {}".format(v['pip_url']))
 
         print(" - Importing {}".format(v['name']))
-        try_cmd("python -c 'import {}'".format(v['package_name']))
+        try_cmd("python -c 'import {}'".format(
+            v['setup_json']['package_name']))

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Test installing all registered plugins."""
+from __future__ import absolute_import
+from __future__ import print_function
+
+import json
+import six
+import subprocess
+
+
+def try_cmd(cmd):
+    try:
+        out = subprocess.check_output(cmd,
+                                      shell=True,
+                                      stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError:
+        print(out)
+        raise
+
+
+with open('all_data.json', 'r') as handle:
+    data = json.load(handle)
+
+if __name__ == "__main__":
+
+    print("[test installing plugins]")
+    for k, v in six.iteritems(data['plugins']):
+        print(" - Installing {}".format(v['name']))
+        try_cmd("pip install {}".format(v['pip_url']))
+
+        print(" - Importing {}".format(v['name']))
+        try_cmd("python -c 'import {}'".format(v['package_name']))

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -24,9 +24,12 @@ if __name__ == "__main__":
     print("[test installing plugins]")
     for k, v in six.iteritems(data['plugins']):
 
-        print(" - Installing {}".format(v['name']))
-        try_cmd("pip install {}".format(v['pip_url']))
+        # 'registered' plugins aren't installed/tested
+        if v['state'] != 'registered':
 
-        print(" - Importing {}".format(v['name']))
-        try_cmd("python -c 'import {}'".format(
-            v['setup_json']['package_name']))
+            print(" - Installing {}".format(v['name']))
+            try_cmd("pip install {}".format(v['pip_url']))
+
+            print(" - Importing {}".format(v['name']))
+            try_cmd("python -c 'import {}'".format(
+                v['setup_json']['package_name']))

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -7,6 +7,10 @@ from __future__ import print_function
 import json
 import six
 import subprocess
+import os
+
+pwd = os.path.split(os.path.abspath(__file__))[0]
+PLUGINS_FILE_ABS = os.path.join(pwd, os.pardir, 'plugins.json')
 
 
 def try_cmd(cmd):
@@ -16,13 +20,13 @@ def try_cmd(cmd):
         print(exc.output)
 
 
-with open('all_data.json', 'r') as handle:
+with open(PLUGINS_FILE_ABS, 'r') as handle:
     data = json.load(handle)
 
 if __name__ == "__main__":
 
     print("[test installing plugins]")
-    for k, v in six.iteritems(data['plugins']):
+    for k, v in six.iteritems(data):
 
         # 'registered' plugins aren't installed/tested
         if v['state'] != 'registered':
@@ -30,6 +34,7 @@ if __name__ == "__main__":
             print(" - Installing {}".format(v['name']))
             try_cmd("pip install {}".format(v['pip_url']))
 
-            print(" - Importing {}".format(v['name']))
-            try_cmd("python -c 'import {}'".format(
-                v['setup_json']['package_name']))
+            if 'package_name' not in list(v.keys()):
+                v['package_name'] = v['name'].replace('-', '_')
+            print(" - Importing {}".format(v['package_name']))
+            try_cmd("python -c 'import {}'".format(v['package_name']))

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -31,14 +31,24 @@ if __name__ == "__main__":
     print("[test installing plugins]")
     for k, v in six.iteritems(data):
 
+        print(" - {}".format(v['name']))
+
         # 'registered' plugins aren't installed/tested
-        if v['state'] != 'registered':
+        if v['state'] == 'registered':
+            continue
 
-            print(" - Installing {}".format(v['name']))
-            is_installed = try_cmd("pip install {}".format(v['pip_url']))
+        if 'pip_url' not in list(v.keys()):
+            print("  >> WARNING: Missing pip_url key!")
+            continue
 
-            if is_installed:
-                if 'package_name' not in list(v.keys()):
-                    v['package_name'] = v['name'].replace('-', '_')
-                print(" - Importing {}".format(v['package_name']))
-                try_cmd("python -c 'import {}'".format(v['package_name']))
+        print(" - Installing {}".format(v['name']))
+        is_installed = try_cmd("pip install {}".format(v['pip_url']))
+
+        if not is_installed:
+            continue
+
+        if 'package_name' not in list(v.keys()):
+            v['package_name'] = v['name'].replace('-', '_')
+
+        print(" - Importing {}".format(v['package_name']))
+        try_cmd("python -c 'import {}'".format(v['package_name']))

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -15,9 +15,12 @@ PLUGINS_FILE_ABS = os.path.join(pwd, os.pardir, 'plugins.json')
 
 def try_cmd(cmd):
     try:
-        subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
+        return subprocess.check_output(cmd,
+                                       shell=True,
+                                       stderr=subprocess.STDOUT)
     except subprocess.CalledProcessError as exc:
         print(exc.output)
+        return False
 
 
 with open(PLUGINS_FILE_ABS, 'r') as handle:
@@ -32,9 +35,10 @@ if __name__ == "__main__":
         if v['state'] != 'registered':
 
             print(" - Installing {}".format(v['name']))
-            try_cmd("pip install {}".format(v['pip_url']))
+            is_installed = try_cmd("pip install {}".format(v['pip_url']))
 
-            if 'package_name' not in list(v.keys()):
-                v['package_name'] = v['name'].replace('-', '_')
-            print(" - Importing {}".format(v['package_name']))
-            try_cmd("python -c 'import {}'".format(v['package_name']))
+            if is_installed:
+                if 'package_name' not in list(v.keys()):
+                    v['package_name'] = v['name'].replace('-', '_')
+                print(" - Importing {}".format(v['package_name']))
+                try_cmd("python -c 'import {}'".format(v['package_name']))

--- a/make_ghpages/test_install.py
+++ b/make_ghpages/test_install.py
@@ -11,12 +11,9 @@ import subprocess
 
 def try_cmd(cmd):
     try:
-        out = subprocess.check_output(cmd,
-                                      shell=True,
-                                      stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError:
-        print(out)
-        raise
+        subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as exc:
+        print(exc.output)
 
 
 with open('all_data.json', 'r') as handle:
@@ -26,6 +23,7 @@ if __name__ == "__main__":
 
     print("[test installing plugins]")
     for k, v in six.iteritems(data['plugins']):
+
         print(" - Installing {}".format(v['name']))
         try_cmd("pip install {}".format(v['pip_url']))
 

--- a/plugins.json
+++ b/plugins.json
@@ -154,7 +154,8 @@
         "entry_point": "raspa",
         "state": "development",
         "plugin_info": "https://raw.github.com/yakutovicha/aiida-raspa/master/setup.json",
-        "code_home": "https://github.com/yakutovicha/aiida-raspa"
+        "code_home": "https://github.com/yakutovicha/aiida-raspa",
+        "pip_url": "aiida-raspa"
     },
     "zeopp": {
         "name": "aiida-zeopp",

--- a/plugins.json
+++ b/plugins.json
@@ -341,7 +341,7 @@
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/pzarabadip/aiida-porousmaterials/master/setup.json",
         "code_home": "https://github.com/pzarabadip/aiida-porousmaterials",
-        "pip_url": "aiida-porousmaterials"
+        "pip_url": "git+https://github.com/pzarabadip/aiida-porousmaterials"
     },
     "plumed": {
         "name": "aiida-plumed",

--- a/plugins.json
+++ b/plugins.json
@@ -68,7 +68,7 @@
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/sphuber/aiida-quantumespresso-hp/master/setup.json",
         "code_home": "https://github.com/sphuber/aiida-quantumespresso-hp",
-        "pip_url": "git+https://github.com/aiidateam/aiida-quantumespresso-hp"
+        "pip_url": "git+https://github.com/sphuber/aiida-quantumespresso-hp"
     },
     "fleur": {
         "name": "aiida-fleur",
@@ -211,7 +211,7 @@
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/yakutovicha/aiida-ddec/master/setup.json",
         "code_home": "https://github.com/yakutovicha/aiida-ddec",
-        "pip_url": "aiida-ddec"
+        "pip_url": "git+https://github.com/yakutovicha/aiida-ddec"
     },
     "crystal17": {
         "name": "aiida-crystal17",

--- a/plugins.json
+++ b/plugins.json
@@ -182,7 +182,7 @@
         "pip_url": "aiida-phtools"
     },
     "widgets": {
-        "name": "aiidalab-widgets",
+        "name": "aiidalab-widgets-base",
         "state": "development",
         "plugin_info": "https://raw.github.com/aiidalab/aiidalab-widgets-base/master/setup.json",
         "code_home": "https://github.com/aiidalab/aiidalab-widgets-base",

--- a/plugins.json
+++ b/plugins.json
@@ -170,7 +170,7 @@
         "state": "development",
         "plugin_info": "https://raw.github.com/ltalirz/aiida-gudhi/master/setup.json",
         "code_home": "https://github.com/ltalirz/aiida-gudhi",
-        "pip_url": "aiida-zeopp"
+        "pip_url": "aiida-gudhi"
     },
     "phtools": {
         "name": "aiida-phtools",
@@ -181,11 +181,11 @@
         "pip_url": "aiida-phtools"
     },
     "widgets": {
-        "name": "aiida-widgets",
+        "name": "aiidalab-widgets",
         "state": "development",
-        "plugin_info": "https://raw.github.com/materialscloud-org/mc-aiida-widgets/master/setup.json",
-        "code_home": "https://github.com/materialscloud-org/mc-aiida-widgets",
-        "pip_url": "aiida-widgets"
+        "plugin_info": "https://raw.github.com/aiidalab/aiidalab-widgets-base/master/setup.json",
+        "code_home": "https://github.com/aiidalab/aiidalab-widgets-base",
+        "pip_url": "aiidalab-widgets-base"
     },
     "kkr": {
         "name": "aiida-kkr",
@@ -339,7 +339,7 @@
         "name": "aiida-porousmaterials",
         "entry_point": "porousmaterials",
         "state": "development",
-        "plugin_info": "https://github.com/pzarabadip/aiida-porousmaterials/blob/master/setup.json",
+        "plugin_info": "https://raw.githubusercontent.com/pzarabadip/aiida-porousmaterials/master/setup.json",
         "code_home": "https://github.com/pzarabadip/aiida-porousmaterials",
         "pip_url": "aiida-porousmaterials"
     },

--- a/plugins.json
+++ b/plugins.json
@@ -4,28 +4,28 @@
         "package_name": "aiida",
         "entry_point": "",
         "state": "stable",
-        "pip_url": "git+https://github.com/aiidateam/aiida-core",
+        "pip_url": "aiida-core==1.0.0b6",
         "plugin_info": "https://raw.githubusercontent.com/aiidateam/aiida-core/v1.0.0b6/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-core",
-        "documentation_url": "http://aiida-core.readthedocs.io/"
+        "documentation_url": "https://aiida-core.readthedocs.io/"
     },
     "quantumespresso": {
         "name": "aiida-quantumespresso",
         "entry_point": "quantumespresso",
         "state": "stable",
-        "pip_url": "git+https://github.com/aiidateam/aiida-quantumespresso",
+        "pip_url": "aiida-quantumespresso",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-quantumespresso/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-quantumespresso",
-        "documentation_url": "http://aiida-quantumespresso.readthedocs.io/"
+        "documentation_url": "https://aiida-quantumespresso.readthedocs.io/"
     },
     "wannier90": {
         "name": "aiida-wannier90",
         "entry_point": "wannier90",
         "state": "stable",
-        "pip_url": "git+https://github.com/aiidateam/aiida-wannier90",
+        "pip_url": "aiida-wannier90",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-wannier90/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-wannier90",
-        "documentation_url": "http://aiida-wannier90.readthedocs.io/"
+        "documentation_url": "https://aiida-wannier90.readthedocs.io/"
     },
     "diff": {
         "name": "aiida-diff",
@@ -34,16 +34,17 @@
         "pip_url": "git+https://github.com/aiidateam/aiida-diff#egg=aiida-diff-0.1.0a0",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-diff/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-diff",
-        "documentation_url": "http://aiida-diff.readthedocs.io/"
+        "documentation_url": "https://aiida-diff.readthedocs.io/"
     },
     "vasp": {
         "name": "aiida-vasp",
         "entry_point": "vasp",
         "state": "development",
+        "pip_url": "aiida-vasp",
         "code_home": "https://github.com/aiida-vasp/aiida-vasp",
         "plugin_info": "https://raw.githubusercontent.com/aiida-vasp/aiida-vasp/develop/setup.json",
         "pip_url": "aiida-vasp",
-        "documentation_url": "http://aiida-vasp.readthedocs.io/"
+        "documentation_url": "https://aiida-vasp.readthedocs.io/"
     },
     "alloy":{
         "name": "aiida-alloy",
@@ -51,21 +52,23 @@
         "state": "registered",
         "code_home": "https://github.com/DanielMarchand/aiida-alloy",
         "plugin_info": "https://raw.githubusercontent.com/DanielMarchand/aiida-alloy/master/setup.json",
-        "pip_url": "aiida-alloy"
+        "pip_url": "git+https://github.com/aiidateam/aiida-alloy"
     },
     "cp2k": {
         "name": "aiida-cp2k",
         "entry_point": "cp2k",
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/cp2k/aiida-cp2k/master/setup.json",
-        "code_home": "https://github.com/cp2k/aiida-cp2k"
+        "code_home": "https://github.com/cp2k/aiida-cp2k",
+        "pip_url": "aiida-cp2k"
     },
     "quantumespresso-hp": {
         "name": "aiida-quantumespresso-hp",
         "entry_point": "quantumespresso.hp",
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/sphuber/aiida-quantumespresso-hp/master/setup.json",
-        "code_home": "https://github.com/sphuber/aiida-quantumespresso-hp"
+        "code_home": "https://github.com/sphuber/aiida-quantumespresso-hp",
+        "pip_url": "git+https://github.com/aiidateam/aiida-quantumespresso-hp"
     },
     "fleur": {
         "name": "aiida-fleur",
@@ -74,22 +77,22 @@
         "pip_url": "aiida-fleur",
         "plugin_info": "https://raw.github.com/JuDFTteam/aiida-fleur/develop/setup.json",
         "code_home": "https://github.com/JuDFTteam/aiida-fleur/tree/develop",
-        "documentation_url": "http://aiida-fleur.readthedocs.io/"
+        "documentation_url": "https://aiida-fleur.readthedocs.io/"
     },
     "siesta": {
         "name": "aiida-siesta",
         "entry_point": "siesta",
         "state": "development",
-        "pip_url": "git+https://github.com/albgar/aiida_siesta_plugin",
+        "pip_url": "aiida-siesta",
         "plugin_info": "https://raw.github.com/albgar/aiida_siesta_plugin/master/setup.json",
         "code_home": "https://github.com/albgar/aiida_siesta_plugin/tree/master",
-        "documentation_url": "http://aiida-siesta-plugin.readthedocs.io/"
+        "documentation_url": "https://aiida-siesta-plugin.readthedocs.io/"
     },
     "yambo": {
-        "name": "yambo-aiida",
+        "name": "aiida-yambo",
         "entry_point": "yambo",
         "state": "development",
-        "pip_url": "git+https://github.com/yambo-code/yambo-aiida/",
+        "pip_url": "aiida-yambo",
         "plugin_info": "https://raw.github.com/yambo-code/yambo-aiida/develop/setup.json",
         "code_home": "https://github.com/yambo-code/yambo-aiida/"
     },
@@ -97,28 +100,28 @@
         "name": "aiida-ase",
         "entry_point": "ase",
         "state": "stable",
-        "pip_url": "git+https://github.com/aiidateam/aiida-ase#egg=aiida-ase-0.1.0",
+        "pip_url": "aiida-ase",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-ase/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-ase",
-        "documentation_url": "http://aiida-ase.readthedocs.io/"
+        "documentation_url": "https://aiida-ase.readthedocs.io/"
     },
     "codtools": {
         "name": "aiida-codtools",
         "entry_point": "codtools",
         "state": "stable",
-        "pip_url": "git+https://github.com/aiidateam/aiida-codtools#egg=aiida-codtools-0.1.0",
+        "pip_url": "aiida-codtools",
         "plugin_info": "https://raw.githubusercontent.com/aiidateam/aiida-codtools/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-codtools",
-        "documentation_url": "http://aiida-codtools.readthedocs.io/"
+        "documentation_url": "https://aiida-codtools.readthedocs.io/"
     },
     "nwchem": {
         "name": "aiida-nwchem",
         "entry_point": "nwchem",
         "state": "stable",
-        "pip_url": "git+https://github.com/aiidateam/aiida-nwchem#egg=aiida-nwchem-0.1.0",
+        "pip_url": "aiida-nwchem",
         "plugin_info": "https://raw.githubusercontent.com/aiidateam/aiida-nwchem/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-nwchem",
-        "documentation_url": "http://aiida-nwchem.readthedocs.io/"
+        "documentation_url": "https://aiida-nwchem.readthedocs.io/"
     },
     "phonopy": {
         "name": "aiida-phonopy",
@@ -126,13 +129,15 @@
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/abelcarreras/aiida-phonopy/master/setup.json",
         "code_home": "https://github.com/abelcarreras/aiida-phonopy",
-        "documentation_url": "http://aiida-phonopy.readthedocs.io/"
+        "pip_url": "git+https://github.com/abelcarreras/aiida-phonopy",
+        "documentation_url": "https://aiida-phonopy.readthedocs.io/"
     },
     "lammps": {
         "name": "aiida-lammps",
         "entry_point": "lammps",
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/abelcarreras/aiida-lammps/master/setup.json",
+        "pip_url": "git+https://github.com/abelcarreras/aiida-lammps",
         "code_home": "https://github.com/abelcarreras/aiida-lammps"
     },
     "castep": {
@@ -141,7 +146,8 @@
         "state": "development",
         "plugin_info": "https://gitlab.com/bz1/aiida-castep/raw/master/setup.json",
         "code_home": "https://gitlab.com/bz1/aiida-castep",
-        "documentation_url": "http://aiida-castep.readthedocs.io/"
+        "documentation_url": "https://aiida-castep.readthedocs.io/",
+        "pip_url": "aiida-castep"
     },
     "raspa": {
         "name": "aiida-raspa",
@@ -155,27 +161,31 @@
         "entry_point": "zeopp",
         "state": "stable",
         "plugin_info": "https://raw.github.com/ltalirz/aiida-zeopp/master/setup.json",
-        "code_home": "https://github.com/ltalirz/aiida-zeopp"
+        "code_home": "https://github.com/ltalirz/aiida-zeopp",
+        "pip_url": "aiida-zeopp"
     },
     "gudhi": {
         "name": "aiida-gudhi",
         "entry_point": "gudhi",
         "state": "development",
         "plugin_info": "https://raw.github.com/ltalirz/aiida-gudhi/master/setup.json",
-        "code_home": "https://github.com/ltalirz/aiida-gudhi"
+        "code_home": "https://github.com/ltalirz/aiida-gudhi",
+        "pip_url": "aiida-zeopp"
     },
     "phtools": {
         "name": "aiida-phtools",
         "entry_point": "phtools",
         "state": "development",
         "plugin_info": "https://raw.github.com/ltalirz/aiida-phtools/master/setup.json",
-        "code_home": "https://github.com/ltalirz/aiida-phtools"
+        "code_home": "https://github.com/ltalirz/aiida-phtools",
+        "pip_url": "aiida-phtools"
     },
     "widgets": {
         "name": "aiida-widgets",
         "state": "development",
         "plugin_info": "https://raw.github.com/materialscloud-org/mc-aiida-widgets/master/setup.json",
-        "code_home": "https://github.com/materialscloud-org/mc-aiida-widgets"
+        "code_home": "https://github.com/materialscloud-org/mc-aiida-widgets",
+        "pip_url": "aiida-widgets"
     },
     "kkr": {
         "name": "aiida-kkr",
@@ -183,22 +193,25 @@
         "state": "development",
         "plugin_info": "https://raw.github.com/JuDFTteam/aiida-kkr/develop/setup.json",
         "code_home": "https://github.com/JuDFTteam/aiida-kkr/tree/develop",
-        "documentation_url": "http://aiida-kkr.readthedocs.io/"
+        "documentation_url": "https://aiida-kkr.readthedocs.io/",
+        "pip_url": "aiida-kkr"
     },
     "gollum": {
         "name": "aiida-gollum",
         "entry_point": "gollum",
         "state": "development",
         "plugin_info": "https://raw.github.com/garsua/aiida-gollum/master/setup.json",
-        "code_home": "http://github.com/garsua/aiida-gollum/",
-        "documentation_url": "http://aiida-gollum.readthedocs.io/"
+        "code_home": "https://github.com/garsua/aiida-gollum/",
+        "documentation_url": "https://aiida-gollum.readthedocs.io/",
+        "pip_url": "git+https://github.com/garsua/aiida-gollum"
     },
     "ddec": {
         "name": "aiida-ddec",
         "entry_point": "ddec",
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/yakutovicha/aiida-ddec/master/setup.json",
-        "code_home": "http://github.com/yakutovicha/aiida-ddec"
+        "code_home": "https://github.com/yakutovicha/aiida-ddec",
+        "pip_url": "aiida-ddec"
     },
     "crystal17": {
         "name": "aiida-crystal17",
@@ -206,27 +219,31 @@
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/chrisjsewell/aiida-crystal17/master/setup.json",
         "documentation_url": "https://aiida-crystal17.readthedocs.io",
-        "code_home": "http://github.com/chrisjsewell/aiida-crystal17"
+        "code_home": "https://github.com/chrisjsewell/aiida-crystal17",
+        "pip_url": "aiida-crystal17"
     },
     "z2pack": {
         "name":"aiida-z2pack",
         "entry_point":"z2pack",
         "state":"registered",
-        "code_home":"http://github.com/AntimoMarrazzo/aiida-z2pack"
+        "code_home":"https://github.com/AntimoMarrazzo/aiida-z2pack",
+        "pip_url":"git+https://github.com/AntimoMarrazzo/aiida-z2pack"
     },
     "spex": {
         "name": "aiida-spex",
         "entry_point": "spex",
         "state": "registered",
-        "code_home": "http://github.com/JuDFTteam/aiida-spex",
-        "plugin_info": "https://raw.githubusercontent.com/JuDFTteam/aiida-spex/master/setup.json"
+        "code_home": "https://github.com/JuDFTteam/aiida-spex",
+        "plugin_info": "https://raw.githubusercontent.com/JuDFTteam/aiida-spex/master/setup.json",
+        "pip_url": "git+https://github.com/JuDFTteam/aiida-spex"
     },
     "qeq": {
         "name": "aiida-qeq",
         "entry_point": "qeq",
         "state": "stable",
         "plugin_info": "https://raw.githubusercontent.com/ltalirz/aiida-qeq/master/setup.json",
-        "code_home": "http://github.com/ltalirz/aiida-qeq"
+        "code_home": "https://github.com/ltalirz/aiida-qeq",
+        "pip_url": "aiida-qeq"
     },
     "optimize": {
         "name": "aiida-optimize",
@@ -289,13 +306,13 @@
         "pip_url": "git+https://github.com/aiidateam/aiida-tcod",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-tcod/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-tcod",
-        "documentation_url": "http://aiida-tcod.readthedocs.io/"
+        "documentation_url": "https://aiida-tcod.readthedocs.io/"
     },
     "gaussian-datatypes": {
         "name": "aiida-gaussian-datatypes",
         "entry_point": "gaussian",
         "state": "development",
-        "pip_url": "git+https://github.com/dev-zero/aiida-gaussian-datatypes",
+        "pip_url": "aiida-gaussian-datatypes",
         "plugin_info": "https://raw.github.com/dev-zero/aiida-gaussian-datatypes/master/setup.json",
         "code_home": "https://github.com/dev-zero/aiida-gaussian-datatypes",
         "documentation_url": "https://github.com/dev-zero/aiida-gaussian-datatypes/blob/master/README.md"
@@ -304,7 +321,7 @@
         "name": "aiida-uppasd",
         "entry_point": "uppasd",
         "state": "registered",
-        "pip_url": "aiida-uppasd",
+        "pip_url": "git+https://github.com/unkcpz/aiida-uppasd",
         "plugin_info": "https://raw.github.com/uppasd/aiida-uppasd/master/setup.json",
         "code_home": "https://github.com/uppasd/aiida-uppasd",
         "documentation_url": "https://github.com/uppasd/aiida-uppasd/blob/master/README.md"
@@ -315,15 +332,16 @@
         "state": "registered",
         "code_home": "https://github.com/unkcpz/aiida-hea",
         "plugin_info": "https://raw.github.com/unkcpz/aiida-hea/master/setup.json",
-        "pip_url": "aiida-hea",
-        "documentation_url": "http://aiida-hea.readthedocs.io/"
+        "pip_url": "git+https://github.com/unkcpz/aiida-hea",
+        "documentation_url": "https://aiida-hea.readthedocs.io/"
     },
     "porousmaterials": {
         "name": "aiida-porousmaterials",
         "entry_point": "porousmaterials",
         "state": "development",
         "plugin_info": "https://github.com/pzarabadip/aiida-porousmaterials/blob/master/setup.json",
-        "code_home": "https://github.com/pzarabadip/aiida-porousmaterials"
+        "code_home": "https://github.com/pzarabadip/aiida-porousmaterials",
+        "pip_url": "aiida-porousmaterials"
     },
     "plumed": {
         "name": "aiida-plumed",
@@ -332,6 +350,6 @@
         "code_home": "https://github.com/ConradJohnston/aiida-plumed",
         "plugin_info": "https://raw.github.com/ConradJohnston/aiida-plumed/AiiDA-v1.0-compatibility/setup.json",
         "pip_url": "aiida-plumed",
-        "documentation_url": "http://aiida-plumed.readthedocs.io/"
+        "documentation_url": "https://aiida-plumed.readthedocs.io/"
     }
 }


### PR DESCRIPTION
fix #23

 * add installation instructions based on pip_url
 * update/fix pip_urls of all packages
 * replace http by https
 * actually try installing & importing all plugins (except for the ones in `registered` state)
    for the moment, this is done in a separate travis job that is allowed to fail