### PR TITLE
naming issues

### DIFF
--- a/make_ghpages/mod/templates/base.html
+++ b/make_ghpages/mod/templates/base.html
@@ -23,7 +23,7 @@
     {% block header %} 
     <header id='entrytitle' style="background-color: #000; margin: 0; padding: 5px 20px 25px 20px;">
         <h1>
-            <a href="http://www.aiida.net/">AiiDA</a> registry of plugins
+            <a href="http://www.aiida.net/">AiiDA</a> plugin registry
         </h1>
         <p style="font-size: 90%;"><a href="http://github.com/aiidateam/aiida-registry" style="color: #999;">[View on GitHub/register your plugin]</a> </p>
       </header>

--- a/make_ghpages/mod/templates/main_index.html
+++ b/make_ghpages/mod/templates/main_index.html
@@ -7,14 +7,13 @@
 
 {% block body %}
 <main>
-    <h1>Global summary of the AiiDA plugin registry</h1>
-    <h2 style="padding-top: 0px">Total number of entries: {{ plugins | length }}</h2>
+    <h2>Registered packages: {{ plugins | length }}</h2>
     <div class='globalsummary-box'>
         <div style="display: table;">
             {% for summaryentry in globalsummary %}
             <span class="badge" style="display: table-row; line-height: 2;"> 
                 <span style="display: table-cell; float: none; text-align: right;"><span class="badge-left {{summaryentry.colorclass}} tooltip" style="float: none; display: inline; text-align: right; border: none">{{summaryentry.name}}{% if summaryentry.tooltip %}<span class="tooltiptext">{{ summaryentry.tooltip}}</span>{% endif %}</span></span>
-                <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right" style="float: none; display: inline; text-align: left; border: none">{{ summaryentry.total_num }} plugin{% if summaryentry.total_num != 1 %}s{% endif %} in {{ summaryentry.num_entries }} entr{% if summaryentry.num_entries != 1 %}ies{%else%}y{% endif %} </span></span>
+                <span style="display: table-cell; float: none; text-align: left;"><span class="badge-right" style="float: none; display: inline; text-align: left; border: none">{{ summaryentry.total_num }} plugin{% if summaryentry.total_num != 1 %}s{% endif %} in {{ summaryentry.num_entries }} package{% if summaryentry.num_entries != 1 %}s{% endif %} </span></span>
             </span>
         {% endfor %}
         </div>
@@ -22,7 +21,7 @@
     </div>
 
     <h1>
-        Available plugins (alphabetically sorted)
+        Available plugins (alphabetical order)
     </h1>
 
     <div id='entrylist'>
@@ -41,21 +40,6 @@
             {%- if plugin.aiida_version -%}
             <span class=aiida_version>, compatible with aiida-core{{plugin.aiida_version}}</span>
             {%- endif -%}    
-        </p>
-        <p><a href="{{ plugin.code_home }}" target="_blank">Plugin code homepage</a> 
-        {% if plugin.hosted_on %}
-        <span style="font-size: 90%">(hosted on {{ plugin.hosted_on }})</span>
-        {% endif %}
-        </p>
-        {% if plugin.documentation_url %}
-            <p>
-                <strong>Documentation</strong>: <a href="{{ plugin.documentation_url }}" target="_blank">Go to plugin documentation</a>
-            <p>
-        {% else %}
-            <p>
-                <strong>Documentation</strong>: Documentation not provided by the plugin author
-            <p>
-        {% endif %}
 	{% if plugin.summaryinfo %}
         <p class="summaryinfo">
             {% for summaryinfoelem in plugin.summaryinfo %}
@@ -66,6 +50,22 @@
             {% endfor %}
         </p>
 	{% endif %}
+        </p>
+        <p><a href="{{ plugin.code_home }}" target="_blank">Code homepage</a>
+        {% if plugin.hosted_on %}
+        <span style="font-size: 90%">(hosted on {{ plugin.hosted_on }})</span>
+        {% endif %}
+        </p>
+        {% if plugin.documentation_url %}
+            <p>
+                <a href="{{ plugin.documentation_url }}" target="_blank">Documentation</a>
+            <p>
+        {% else %}
+            <p>
+                No documentation provided by plugin author.
+            <p>
+        {% endif %}
+
         <p class='details'><a href="{{ plugin.subpage }}">Show plugin details</a></p>
         </div>
         

--- a/make_ghpages/mod/templates/singlepage.html
+++ b/make_ghpages/mod/templates/singlepage.html
@@ -66,7 +66,7 @@
         </p>
 
         {% if summaryinfo %}
-        <h3>Summary of the entrypoints</h3>
+        <h3>Summary of the entry points</h3>
         This plugin contains: <br>
         {% for summaryinfoelem in summaryinfo %}
         <span class="badge"> 
@@ -76,7 +76,7 @@
         {% endfor %}
         {% endif %}
 
-        <h3>Available entrypoints</h3>
+        <h3>Available entry points</h3>
         {% if setup_json.entry_points %}
 
             {% for entrypointtype, entrypointlist in setup_json.entry_points.items() %}
@@ -97,7 +97,7 @@
                 </ul>
             {% endfor %}
         {% else %}
-        <p>No entrypoints defined for this plugin.</p>
+        <p>No entry points defined for this plugin.</p>
         {% endif %}
     </div>
     {% else %}


### PR DESCRIPTION
 * harmonize display of code homepage and documentation
 * entrypoint => entry point
 * remove "global summary header"
 * main_index: replace "entry" with "package" (as used below)