### PR TITLE
switch source of aiida-vasp setup.json to master

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -42,7 +42,7 @@
         "state": "development",
         "pip_url": "aiida-vasp",
         "code_home": "https://github.com/aiida-vasp/aiida-vasp",
-        "plugin_info": "https://raw.githubusercontent.com/aiida-vasp/aiida-vasp/develop/setup.json",
+        "plugin_info": "https://raw.githubusercontent.com/aiida-vasp/aiida-vasp/master/setup.json",
         "pip_url": "aiida-vasp",
         "documentation_url": "https://aiida-vasp.readthedocs.io/"
     },


### PR DESCRIPTION
setup.json of aiida-vasp was taken from develop branch, leading to inconsistency between version displayed on plugin registry and latest release

mentioning @espenfl for info (no action needed)