### PR TITLE
check only entry points in aiida groups

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
     python: 3.7
     env:
     - JOB: INSTALL
+  - name: Run tests (py37)
+    python: 3.7
+    env:
+    - JOB: TEST
 
   allow_failures:
   - name: Install plugins (py27)
@@ -33,6 +37,7 @@ install:
 script: 
   - if [ "$JOB" == "HTML" ]; then aiida-registry html && cd .travis-data && ./deploy.sh; fi
   - if [ "$JOB" == "INSTALL" ]; then aiida-registry test-install; fi
+  - if [ "$JOB" == "TEST" ]; then pytest tests/; fi
 
 ## See docs here: https://docs.travis-ci.com/user/deployment/pages/
 ## This works, but we're not using it to avoid to have global tokens.

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ if __name__ == '__main__':
                 "prospector==1.1.7",
                 "pylint==1.9.4; python_version<'3.0'",
                 "pylint==2.3.1; python_version>='3.0'",
-            ]
+            ],
+            'testing': ['pytest'],
         },
     )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Tests of the AiiDA plugin registry code.
+
+Note: Here we are testing the *code* of the registry, not validating actual entries.
+"""
+
+from __future__ import absolute_import
+from __future__ import print_function
+import os
+import json
+
+# Absolute paths
+pwd = os.path.split(os.path.abspath(__file__))[0]
+TEST_DATA_ABS = os.path.join(pwd, 'test_metadata.json')
+
+with open(TEST_DATA_ABS) as f:
+    TEST_DATA = json.load(f)

--- a/tests/test_metadata.json
+++ b/tests/test_metadata.json
@@ -1,0 +1,4388 @@
+{
+  "alloy": {
+    "name": "aiida-alloy",
+    "entry_point": "alloy",
+    "state": "registered",
+    "code_home": "https://github.com/DanielMarchand/aiida-alloy",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-alloy",
+        "author": "Daniel Marchand, Albert Glensk",
+        "author_email": "daniel.marchand@gmail.com",
+        "description": "AiiDA plugin for studying alloys",
+        "url": "https://github.com/DanielMarchand/aiida-alloy",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python"
+        ],
+        "version": "0.1.0a0",
+        "entry_points": {
+          "aiida.data": [
+            "alloy = aiida_alloy.data:DiffParameters"
+          ],
+          "aiida.calculations": [
+            "alloy = aiida_alloy.calculations:DiffCalculation"
+          ],
+          "aiida.parsers": [
+            "alloy = aiida_alloy.parsers:DiffParser"
+          ],
+          "aiida.cmdline.data": [
+            "alloy = aiida_alloy.cli.data:data_cli"
+          ],
+          "console_scripts": [
+            "create_randomsupercell_structures = aiida_alloy.cli.create_randomsupercell_structures:cli",
+            "create_surface_structures = aiida_alloy.cli.create_surface_structures:cli",
+            "create_solutesupercell_structures = aiida_alloy.cli.create_solutesupercell_structures:cli",
+            "create_stackingfault_structures = aiida_alloy.cli.create_stackingfault_structures:cli",
+            "dump_group_to_runner = aiida_alloy.cli.dump_group_to_runner:cli",
+            "launch_workflow_alloy = aiida_alloy.cli.launch_workflow_alloy:cli",
+            "load_oqmd_dump = aiida_alloy.cli.load_oqmd_dump:cli",
+            "load_runner_dump = aiida_alloy.cli.load_runner_dump:cli"
+          ]
+        },
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0b1,<2.0.0",
+          "six",
+          "voluptuous"
+        ],
+        "extras_require": {
+          "testing": [
+            "mock==2.0.0",
+            "pgtest==1.2.0",
+            "sqlalchemy-diff==0.1.3",
+            "wheel>=0.31",
+            "coverage",
+            "pytest==3.6.3",
+            "pytest-cov==2.6.0"
+          ],
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.26.0",
+            "prospector==0.12.11",
+            "pylint==1.9.4"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "pip_url": "git+https://github.com/aiidateam/aiida-alloy",
+    "package_name": "aiida_alloy",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.data": [
+        "alloy = aiida_alloy.data:DiffParameters"
+      ],
+      "aiida.calculations": [
+        "alloy = aiida_alloy.calculations:DiffCalculation"
+      ],
+      "aiida.parsers": [
+        "alloy = aiida_alloy.parsers:DiffParser"
+      ],
+      "aiida.cmdline.data": [
+        "alloy = aiida_alloy.cli.data:data_cli"
+      ],
+      "console_scripts": [
+        "create_randomsupercell_structures = aiida_alloy.cli.create_randomsupercell_structures:cli",
+        "create_surface_structures = aiida_alloy.cli.create_surface_structures:cli",
+        "create_solutesupercell_structures = aiida_alloy.cli.create_solutesupercell_structures:cli",
+        "create_stackingfault_structures = aiida_alloy.cli.create_stackingfault_structures:cli",
+        "dump_group_to_runner = aiida_alloy.cli.dump_group_to_runner:cli",
+        "launch_workflow_alloy = aiida_alloy.cli.launch_workflow_alloy:cli",
+        "load_oqmd_dump = aiida_alloy.cli.load_oqmd_dump:cli",
+        "load_runner_dump = aiida_alloy.cli.load_runner_dump:cli"
+      ]
+    },
+    "metadata": {
+      "author": "Daniel Marchand, Albert Glensk",
+      "author_email": "daniel.marchand@gmail.com",
+      "version": "0.1.0a0",
+      "description": "AiiDA plugin for studying alloys",
+      "classifiers": [
+        "Programming Language :: Python"
+      ]
+    },
+    "aiida_version": ">=1.0.0b1,<2.0.0"
+  },
+  "ase": {
+    "name": "aiida-ase",
+    "entry_point": "ase",
+    "state": "stable",
+    "pip_url": "aiida-ase",
+    "plugin_info": [
+      "setuptools",
+      {
+        "author": "The AiiDA team",
+        "author_email": "developers@aiida.net",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Development Status :: 4 - Beta"
+        ],
+        "description": "The official AiiDA plugin for ASE",
+        "entry_points": {
+          "aiida.calculations": [
+            "ase.ase = aiida_ase.calculations.ase:AseCalculation"
+          ],
+          "aiida.parsers": [
+            "ase.ase = aiida_ase.parsers.ase:AseParser"
+          ]
+        },
+        "extras_require": {
+          "dev_precommit": [
+            "pre-commit"
+          ],
+          "docs": [
+            "Sphinx",
+            "docutils",
+            "sphinx_rtd_theme"
+          ]
+        },
+        "install_requires": [
+          "aiida-core>=0.10.0rc1"
+        ],
+        "license": "MIT License",
+        "name": "aiida_ase",
+        "url": "https://github.com/aiidateam/aiida-ase",
+        "version": "1.0.1"
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-ase",
+    "documentation_url": "https://aiida-ase.readthedocs.io/",
+    "package_name": "aiida_ase",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "ase.ase = aiida_ase.calculations.ase:AseCalculation"
+      ],
+      "aiida.parsers": [
+        "ase.ase = aiida_ase.parsers.ase:AseParser"
+      ]
+    },
+    "metadata": {
+      "author": "The AiiDA team",
+      "author_email": "developers@aiida.net",
+      "version": "1.0.1",
+      "description": "The official AiiDA plugin for ASE",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Development Status :: 4 - Beta"
+      ]
+    },
+    "aiida_version": ">=0.10.0rc1"
+  },
+  "bands-inspect": {
+    "name": "aiida-bands-inspect",
+    "entry_point": "bands_inspect",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-bands-inspect",
+        "description": "AiiDA Plugin for running bands_inspect",
+        "author": "Dominik Gresch",
+        "author_email": "greschd@gmx.ch",
+        "url": "https://aiida-bands-inspect.readthedocs.io",
+        "license": "Apache 2.0",
+        "classifiers": [
+          "Development Status :: 4 - Beta",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: Apache Software License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Topic :: Scientific/Engineering :: Physics",
+          "Framework :: AiiDA"
+        ],
+        "keywords": [
+          "bandstructure",
+          "aiida",
+          "workflows"
+        ],
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "h5py",
+          "aiida-core>=1.0.0a4,<2.0.0",
+          "fsc.export",
+          "six"
+        ],
+        "extras_require": {
+          "dev": [
+            "numpy",
+            "aiida-pytest>=0.1.0a4",
+            "pytest",
+            "yapf==0.28",
+            "pre-commit"
+          ]
+        },
+        "entry_points": {
+          "aiida.calculations": [
+            "bands_inspect.difference = aiida_bands_inspect.calculations.difference:DifferenceCalculation",
+            "bands_inspect.plot = aiida_bands_inspect.calculations.plot:PlotCalculation"
+          ],
+          "aiida.parsers": [
+            "bands_inspect.bands = aiida_bands_inspect.parsers.bands:BandsParser",
+            "bands_inspect.difference = aiida_bands_inspect.parsers.difference:DifferenceParser",
+            "bands_inspect.plot = aiida_bands_inspect.parsers.plot:PlotParser"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/greschd/aiida-bands-inspect",
+    "documentation_url": "https://aiida-bands-inspect.readthedocs.io",
+    "pip_url": "aiida-bands-inspect",
+    "package_name": "aiida_bands_inspect",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "bands_inspect.difference = aiida_bands_inspect.calculations.difference:DifferenceCalculation",
+        "bands_inspect.plot = aiida_bands_inspect.calculations.plot:PlotCalculation"
+      ],
+      "aiida.parsers": [
+        "bands_inspect.bands = aiida_bands_inspect.parsers.bands:BandsParser",
+        "bands_inspect.difference = aiida_bands_inspect.parsers.difference:DifferenceParser",
+        "bands_inspect.plot = aiida_bands_inspect.parsers.plot:PlotParser"
+      ]
+    },
+    "metadata": {
+      "author": "Dominik Gresch",
+      "author_email": "greschd@gmx.ch",
+      "version": "",
+      "description": "AiiDA Plugin for running bands_inspect",
+      "classifiers": [
+        "Development Status :: 4 - Beta",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0a4,<2.0.0"
+  },
+  "castep": {
+    "name": "aiida-castep",
+    "entry_point": "castep",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-castep",
+        "author": "Bonan Zhu",
+        "author_email": "bz240@cam.ac.uk",
+        "classifiers": [
+          "Programming Language :: Python :: 2.7",
+          "Framework :: AiiDA"
+        ],
+        "description": "AiiDA plugin for CASTEP",
+        "url": "https://gitlab.com/bz1/aiida-castep",
+        "license": "MIT License",
+        "version": "0.3.2",
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core >= 0.11.0, <1.0.0",
+          "pgtest==1.1.0",
+          "deepdiff<=3.3.0",
+          "ase",
+          "matplotlib<3",
+          "castepinput==0.1.3"
+        ],
+        "entry_points": {
+          "console_scripts": [
+            "castep.mock = aiida_castep.utils.mock:main"
+          ],
+          "aiida.calculations": [
+            "castep.castep = aiida_castep.calculations.castep:CastepCalculation",
+            "castep.bs = aiida_castep.calculations.castep:CastepBSCalculation",
+            "castep.spec = aiida_castep.calculations.castep:CastepSpectralCalculation",
+            "castep.pot1d = aiida_castep.calculations.castep:Pot1dCalculation",
+            "castep.ts = aiida_castep.calculations.castep:CastepTSCalculation"
+          ],
+          "aiida.parsers": [
+            "castep.castep = aiida_castep.parsers.castep:CastepParser",
+            "castep.pot1d = aiida_castep.parsers.castep:Pot1dParser"
+          ],
+          "aiida.data": [
+            "castep.uspdata = aiida_castep.data.usp:UspData",
+            "castep.otfgdata = aiida_castep.data.otfg:OTFGData"
+          ],
+          "aiida.tests": [
+            "castep.calculation = aiida_castep.tests.dbtestcalculation"
+          ],
+          "aiida.cmdline.data": [
+            "castep-usp = aiida_castep.cmdline.usp_cmd:usp_cmd",
+            "castep-otfg = aiida_castep.cmdline.otfg_cmd:otfg_cmd",
+            "castep-helper = aiida_castep.cmdline.helper_cmd:helper_cmd"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://gitlab.com/bz1/aiida-castep",
+    "documentation_url": "https://aiida-castep.readthedocs.io/",
+    "pip_url": "aiida-castep",
+    "package_name": "aiida_castep",
+    "hosted_on": "gitlab.com",
+    "entry_points": {
+      "console_scripts": [
+        "castep.mock = aiida_castep.utils.mock:main"
+      ],
+      "aiida.calculations": [
+        "castep.castep = aiida_castep.calculations.castep:CastepCalculation",
+        "castep.bs = aiida_castep.calculations.castep:CastepBSCalculation",
+        "castep.spec = aiida_castep.calculations.castep:CastepSpectralCalculation",
+        "castep.pot1d = aiida_castep.calculations.castep:Pot1dCalculation",
+        "castep.ts = aiida_castep.calculations.castep:CastepTSCalculation"
+      ],
+      "aiida.parsers": [
+        "castep.castep = aiida_castep.parsers.castep:CastepParser",
+        "castep.pot1d = aiida_castep.parsers.castep:Pot1dParser"
+      ],
+      "aiida.data": [
+        "castep.uspdata = aiida_castep.data.usp:UspData",
+        "castep.otfgdata = aiida_castep.data.otfg:OTFGData"
+      ],
+      "aiida.tests": [
+        "castep.calculation = aiida_castep.tests.dbtestcalculation"
+      ],
+      "aiida.cmdline.data": [
+        "castep-usp = aiida_castep.cmdline.usp_cmd:usp_cmd",
+        "castep-otfg = aiida_castep.cmdline.otfg_cmd:otfg_cmd",
+        "castep-helper = aiida_castep.cmdline.helper_cmd:helper_cmd"
+      ]
+    },
+    "metadata": {
+      "author": "Bonan Zhu",
+      "author_email": "bz240@cam.ac.uk",
+      "version": "0.3.2",
+      "description": "AiiDA plugin for CASTEP",
+      "classifiers": [
+        "Programming Language :: Python :: 2.7",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=0.11.0,<1.0.0"
+  },
+  "codtools": {
+    "name": "aiida-codtools",
+    "entry_point": "codtools",
+    "state": "stable",
+    "pip_url": "aiida-codtools",
+    "plugin_info": [
+      "setuptools",
+      {
+        "author": "The AiiDA team",
+        "author_email": "developers@aiida.net",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Development Status :: 4 - Beta"
+        ],
+        "description": "The official AiiDA plugin for COD tools",
+        "entry_points": {
+          "aiida.calculations": [
+            "codtools.ciffilter = aiida_codtools.calculations.ciffilter:CiffilterCalculation",
+            "codtools.cifcellcontents = aiida_codtools.calculations.cifcellcontents:CifcellcontentsCalculation",
+            "codtools.cifcodcheck = aiida_codtools.calculations.cifcodcheck:CifcodcheckCalculation",
+            "codtools.cifcoddeposit = aiida_codtools.calculations.cifcoddeposit:CifcoddepositCalculation",
+            "codtools.cifcodnumbers = aiida_codtools.calculations.cifcodnumbers:CifcodnumbersCalculation",
+            "codtools.cifsplitprimitive = aiida_codtools.calculations.cifsplitprimitive:CifsplitprimitiveCalculation"
+          ],
+          "aiida.parsers": [
+            "codtools.cifcellcontents = aiida_codtools.parsers.cifcellcontents:CifcellcontentsParser",
+            "codtools.cifcodcheck = aiida_codtools.parsers.cifcodcheck:CifcodcheckParser",
+            "codtools.cifcoddeposit = aiida_codtools.parsers.cifcoddeposit:CifcoddepositParser",
+            "codtools.cifcodnumbers = aiida_codtools.parsers.cifcodnumbers:CifcodnumbersParser",
+            "codtools.ciffilter = aiida_codtools.parsers.ciffilter:CiffilterParser",
+            "codtools.cifsplitprimitive = aiida_codtools.parsers.cifsplitprimitive:CifsplitprimitiveParser"
+          ]
+        },
+        "extras_require": {
+          "dev_precommit": [
+            "pre-commit"
+          ],
+          "docs": [
+            "Sphinx",
+            "docutils",
+            "sphinx_rtd_theme"
+          ]
+        },
+        "install_requires": [
+          "aiida-core>=0.10.0rc1"
+        ],
+        "license": "MIT License",
+        "name": "aiida_codtools",
+        "url": "https://github.com/aiidateam/aiida-codtools",
+        "version": "1.0.1"
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-codtools",
+    "documentation_url": "https://aiida-codtools.readthedocs.io/",
+    "package_name": "aiida_codtools",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "codtools.ciffilter = aiida_codtools.calculations.ciffilter:CiffilterCalculation",
+        "codtools.cifcellcontents = aiida_codtools.calculations.cifcellcontents:CifcellcontentsCalculation",
+        "codtools.cifcodcheck = aiida_codtools.calculations.cifcodcheck:CifcodcheckCalculation",
+        "codtools.cifcoddeposit = aiida_codtools.calculations.cifcoddeposit:CifcoddepositCalculation",
+        "codtools.cifcodnumbers = aiida_codtools.calculations.cifcodnumbers:CifcodnumbersCalculation",
+        "codtools.cifsplitprimitive = aiida_codtools.calculations.cifsplitprimitive:CifsplitprimitiveCalculation"
+      ],
+      "aiida.parsers": [
+        "codtools.cifcellcontents = aiida_codtools.parsers.cifcellcontents:CifcellcontentsParser",
+        "codtools.cifcodcheck = aiida_codtools.parsers.cifcodcheck:CifcodcheckParser",
+        "codtools.cifcoddeposit = aiida_codtools.parsers.cifcoddeposit:CifcoddepositParser",
+        "codtools.cifcodnumbers = aiida_codtools.parsers.cifcodnumbers:CifcodnumbersParser",
+        "codtools.ciffilter = aiida_codtools.parsers.ciffilter:CiffilterParser",
+        "codtools.cifsplitprimitive = aiida_codtools.parsers.cifsplitprimitive:CifsplitprimitiveParser"
+      ]
+    },
+    "metadata": {
+      "author": "The AiiDA team",
+      "author_email": "developers@aiida.net",
+      "version": "1.0.1",
+      "description": "The official AiiDA plugin for COD tools",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Development Status :: 4 - Beta"
+      ]
+    },
+    "aiida_version": ">=0.10.0rc1"
+  },
+  "core": {
+    "name": "aiida-core",
+    "package_name": "aiida",
+    "entry_point": "",
+    "state": "stable",
+    "pip_url": "aiida-core",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-core",
+        "version": "1.0.0",
+        "url": "http://www.aiida.net/",
+        "license": "MIT License",
+        "author": "The AiiDA team",
+        "author_email": "developers@aiida.net",
+        "include_package_data": true,
+        "classifiers": [
+          "Framework :: AiiDA",
+          "License :: OSI Approved :: MIT License",
+          "Operating System :: POSIX :: Linux",
+          "Operating System :: MacOS :: MacOS X",
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Topic :: Scientific/Engineering"
+        ],
+        "install_requires": [
+          "aldjemy==0.9.1",
+          "alembic==1.2.1",
+          "circus==0.15.0",
+          "click-completion==0.5.1",
+          "click-config-file==0.5.0",
+          "click-spinner==0.1.8",
+          "click==7.0",
+          "django==1.11.25",
+          "enum34==1.1.6; python_version<'3.5'",
+          "ete3==3.1.1",
+          "graphviz==0.13",
+          "ipython>=4.0,<6.0",
+          "kiwipy[rmq]==0.5.1",
+          "mock==3.0.5",
+          "numpy==1.16.4",
+          "paramiko==2.6.0",
+          "passlib==1.7.1",
+          "pika==1.1.0",
+          "plumpy==0.14.3",
+          "psutil==5.6.3",
+          "psycopg2-binary==2.8.3",
+          "pyblake2==1.1.2; python_version<'3.6'",
+          "python-dateutil==2.8.0",
+          "pytz==2019.3",
+          "pyyaml==3.13",
+          "reentry>=1.3.0",
+          "simplejson==3.16.0",
+          "singledispatch>=3.4.0.3; python_version<'3.5'",
+          "six==1.12.0",
+          "sqlalchemy-utils==0.34.2",
+          "sqlalchemy==1.3.10",
+          "tabulate==0.8.5",
+          "tornado<5.0",
+          "typing==3.7.4.1; python_version<'3.5'",
+          "tzlocal==2.0.0",
+          "upf_to_json==0.9.2",
+          "uritools==2.2.0",
+          "wrapt==1.11.2"
+        ],
+        "extras_require": {
+          "ssh_kerberos": [
+            "gssapi==1.6.1",
+            "pyasn1==0.4.7"
+          ],
+          "rest": [
+            "flask-cache==0.13.1",
+            "flask-cors==3.0.8",
+            "flask-httpauth==3.3.0",
+            "flask-marshmallow==0.10.1",
+            "flask-restful==0.3.7",
+            "flask-sqlalchemy==2.4.1",
+            "flask==1.1.1",
+            "itsdangerous==1.1.0",
+            "marshmallow-sqlalchemy==0.19.0",
+            "pyparsing==2.4.2",
+            "python-memcached==1.59",
+            "seekpath==1.9.3",
+            "sqlalchemy-migrate==0.12.0"
+          ],
+          "docs": [
+            "docutils==0.15.2",
+            "jinja2==2.10.3",
+            "markupsafe==1.1.1",
+            "pygments==2.4.2",
+            "sphinx-rtd-theme==0.4.3",
+            "sphinx==1.8.5; python_version<'3'",
+            "sphinx==2.2.0; python_version>='3.0'",
+            "sphinxcontrib-contentui==0.2.2; python_version<'3'",
+            "sphinxcontrib-contentui==0.2.4; python_version>='3.0'",
+            "sphinxcontrib-details-directive==0.1.0; python_version>='3.0'"
+          ],
+          "atomic_tools": [
+            "PyCifRW==4.2.1; python_version < '3'",
+            "PyCifRW==4.4.1; python_version >= '3'",
+            "ase==3.17.0",
+            "monty==2.0.4",
+            "pymatgen<=2018.12.12",
+            "pymysql==0.9.3",
+            "seekpath==1.9.3",
+            "spglib==1.14.1.post0"
+          ],
+          "notebook": [
+            "jupyter==1.0.0",
+            "notebook<6"
+          ],
+          "testing": [
+            "aiida-export-migration-tests==0.7.0",
+            "codecov==2.0.15",
+            "coverage==4.5.4",
+            "futures==3.3.0; python_version=='2.7'",
+            "pg8000<1.13.0",
+            "pgtest==1.3.1",
+            "pytest==4.6.6",
+            "pytest-cov==2.8.1",
+            "mock==3.0.5; python_version<'3.3'",
+            "sqlalchemy-diff==0.1.3",
+            "unittest2==1.1.0; python_version<'3.5'"
+          ],
+          "dev_precommit": [
+            "astroid==1.6.6; python_version<'3.0'",
+            "astroid==2.2.5; python_version>='3.0'",
+            "pep8-naming==0.8.2",
+            "pre-commit==1.18.3",
+            "prospector==1.1.7",
+            "pylint-django==0.11.1; python_version<'3.0'",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.3.1; python_version>='3.0'",
+            "toml==0.10.0",
+            "yapf==0.28.0"
+          ],
+          "bpython": [
+            "bpython==0.17.1"
+          ]
+        },
+        "reentry_register": true,
+        "entry_points": {
+          "console_scripts": [
+            "verdi=aiida.cmdline.commands.cmd_verdi:verdi"
+          ],
+          "aiida.calculations": [
+            "arithmetic.add = aiida.calculations.plugins.arithmetic.add:ArithmeticAddCalculation",
+            "templatereplacer = aiida.calculations.plugins.templatereplacer:TemplatereplacerCalculation"
+          ],
+          "aiida.cmdline.computer.configure": [
+            "local = aiida.transports.plugins.local:CONFIGURE_LOCAL_CMD",
+            "ssh = aiida.transports.plugins.ssh:CONFIGURE_SSH_CMD"
+          ],
+          "aiida.cmdline.data": [
+            "array = aiida.cmdline.commands.cmd_data.cmd_array:array",
+            "bands = aiida.cmdline.commands.cmd_data.cmd_bands:bands",
+            "cif = aiida.cmdline.commands.cmd_data.cmd_cif:cif",
+            "dict = aiida.cmdline.commands.cmd_data.cmd_dict:dictionary",
+            "remote = aiida.cmdline.commands.cmd_data.cmd_remote:remote",
+            "structure = aiida.cmdline.commands.cmd_data.cmd_structure:structure",
+            "trajectory = aiida.cmdline.commands.cmd_data.cmd_trajectory:trajectory",
+            "upf = aiida.cmdline.commands.cmd_data.cmd_upf:upf"
+          ],
+          "aiida.data": [
+            "array = aiida.orm.nodes.data.array.array:ArrayData",
+            "array.bands = aiida.orm.nodes.data.array.bands:BandsData",
+            "array.kpoints = aiida.orm.nodes.data.array.kpoints:KpointsData",
+            "array.projection = aiida.orm.nodes.data.array.projection:ProjectionData",
+            "array.trajectory = aiida.orm.nodes.data.array.trajectory:TrajectoryData",
+            "array.xy = aiida.orm.nodes.data.array.xy:XyData",
+            "base = aiida.orm.nodes.data:BaseType",
+            "bool = aiida.orm.nodes.data.bool:Bool",
+            "cif = aiida.orm.nodes.data.cif:CifData",
+            "code = aiida.orm.nodes.data.code:Code",
+            "dict = aiida.orm.nodes.data.dict:Dict",
+            "float = aiida.orm.nodes.data.float:Float",
+            "folder = aiida.orm.nodes.data.folder:FolderData",
+            "int = aiida.orm.nodes.data.int:Int",
+            "list = aiida.orm.nodes.data.list:List",
+            "numeric = aiida.orm.nodes.data.numeric:NumericType",
+            "orbital = aiida.orm.nodes.data.orbital:OrbitalData",
+            "remote = aiida.orm.nodes.data.remote:RemoteData",
+            "singlefile = aiida.orm.nodes.data.singlefile:SinglefileData",
+            "str = aiida.orm.nodes.data.str:Str",
+            "structure = aiida.orm.nodes.data.structure:StructureData",
+            "upf = aiida.orm.nodes.data.upf:UpfData"
+          ],
+          "aiida.node": [
+            "data = aiida.orm.nodes.data.data:Data",
+            "process = aiida.orm.nodes.process.process:ProcessNode",
+            "process.calculation = aiida.orm.nodes.process.calculation.calculation:CalculationNode",
+            "process.calculation.calcfunction = aiida.orm.nodes.process.calculation.calcfunction:CalcFunctionNode",
+            "process.calculation.calcjob = aiida.orm.nodes.process.calculation.calcjob:CalcJobNode",
+            "process.workflow = aiida.orm.nodes.process.workflow.workflow:WorkflowNode",
+            "process.workflow.workchain = aiida.orm.nodes.process.workflow.workchain:WorkChainNode",
+            "process.workflow.workfunction = aiida.orm.nodes.process.workflow.workfunction:WorkFunctionNode"
+          ],
+          "aiida.parsers": [
+            "arithmetic.add = aiida.parsers.plugins.arithmetic.add:ArithmeticAddParser",
+            "templatereplacer.doubler = aiida.parsers.plugins.templatereplacer.doubler:TemplatereplacerDoublerParser"
+          ],
+          "aiida.schedulers": [
+            "direct = aiida.schedulers.plugins.direct:DirectScheduler",
+            "lsf = aiida.schedulers.plugins.lsf:LsfScheduler",
+            "pbspro = aiida.schedulers.plugins.pbspro:PbsproScheduler",
+            "sge = aiida.schedulers.plugins.sge:SgeScheduler",
+            "slurm = aiida.schedulers.plugins.slurm:SlurmScheduler",
+            "torque = aiida.schedulers.plugins.torque:TorqueScheduler"
+          ],
+          "aiida.transports": [
+            "local = aiida.transports.plugins.local:LocalTransport",
+            "ssh = aiida.transports.plugins.ssh:SshTransport"
+          ],
+          "aiida.tools.calculations": [],
+          "aiida.tools.dbexporters": [],
+          "aiida.tools.dbimporters": [
+            "cod = aiida.tools.dbimporters.plugins.cod:CodDbImporter",
+            "icsd = aiida.tools.dbimporters.plugins.icsd:IcsdDbImporter",
+            "materialsproject = aiida.tools.dbimporters.plugins.materialsproject:MaterialsProjectImporter",
+            "mpds = aiida.tools.dbimporters.plugins.mpds:MpdsDbImporter",
+            "mpod = aiida.tools.dbimporters.plugins.mpod:MpodDbImporter",
+            "nninc = aiida.tools.dbimporters.plugins.nninc:NnincDbImporter",
+            "oqmd = aiida.tools.dbimporters.plugins.oqmd:OqmdDbImporter",
+            "pcod = aiida.tools.dbimporters.plugins.pcod:PcodDbImporter",
+            "tcod = aiida.tools.dbimporters.plugins.tcod:TcodDbImporter"
+          ],
+          "aiida.tools.data.orbitals": [
+            "orbital = aiida.tools.data.orbital.orbital:Orbital",
+            "realhydrogen = aiida.tools.data.orbital.realhydrogen:RealhydrogenOrbital"
+          ],
+          "aiida.workflows": []
+        },
+        "scripts": [
+          "bin/runaiida"
+        ]
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-core",
+    "documentation_url": "https://aiida-core.readthedocs.io/",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "console_scripts": [
+        "verdi=aiida.cmdline.commands.cmd_verdi:verdi"
+      ],
+      "aiida.calculations": [
+        "arithmetic.add = aiida.calculations.plugins.arithmetic.add:ArithmeticAddCalculation",
+        "templatereplacer = aiida.calculations.plugins.templatereplacer:TemplatereplacerCalculation"
+      ],
+      "aiida.cmdline.computer.configure": [
+        "local = aiida.transports.plugins.local:CONFIGURE_LOCAL_CMD",
+        "ssh = aiida.transports.plugins.ssh:CONFIGURE_SSH_CMD"
+      ],
+      "aiida.cmdline.data": [
+        "array = aiida.cmdline.commands.cmd_data.cmd_array:array",
+        "bands = aiida.cmdline.commands.cmd_data.cmd_bands:bands",
+        "cif = aiida.cmdline.commands.cmd_data.cmd_cif:cif",
+        "dict = aiida.cmdline.commands.cmd_data.cmd_dict:dictionary",
+        "remote = aiida.cmdline.commands.cmd_data.cmd_remote:remote",
+        "structure = aiida.cmdline.commands.cmd_data.cmd_structure:structure",
+        "trajectory = aiida.cmdline.commands.cmd_data.cmd_trajectory:trajectory",
+        "upf = aiida.cmdline.commands.cmd_data.cmd_upf:upf"
+      ],
+      "aiida.data": [
+        "array = aiida.orm.nodes.data.array.array:ArrayData",
+        "array.bands = aiida.orm.nodes.data.array.bands:BandsData",
+        "array.kpoints = aiida.orm.nodes.data.array.kpoints:KpointsData",
+        "array.projection = aiida.orm.nodes.data.array.projection:ProjectionData",
+        "array.trajectory = aiida.orm.nodes.data.array.trajectory:TrajectoryData",
+        "array.xy = aiida.orm.nodes.data.array.xy:XyData",
+        "base = aiida.orm.nodes.data:BaseType",
+        "bool = aiida.orm.nodes.data.bool:Bool",
+        "cif = aiida.orm.nodes.data.cif:CifData",
+        "code = aiida.orm.nodes.data.code:Code",
+        "dict = aiida.orm.nodes.data.dict:Dict",
+        "float = aiida.orm.nodes.data.float:Float",
+        "folder = aiida.orm.nodes.data.folder:FolderData",
+        "int = aiida.orm.nodes.data.int:Int",
+        "list = aiida.orm.nodes.data.list:List",
+        "numeric = aiida.orm.nodes.data.numeric:NumericType",
+        "orbital = aiida.orm.nodes.data.orbital:OrbitalData",
+        "remote = aiida.orm.nodes.data.remote:RemoteData",
+        "singlefile = aiida.orm.nodes.data.singlefile:SinglefileData",
+        "str = aiida.orm.nodes.data.str:Str",
+        "structure = aiida.orm.nodes.data.structure:StructureData",
+        "upf = aiida.orm.nodes.data.upf:UpfData"
+      ],
+      "aiida.node": [
+        "data = aiida.orm.nodes.data.data:Data",
+        "process = aiida.orm.nodes.process.process:ProcessNode",
+        "process.calculation = aiida.orm.nodes.process.calculation.calculation:CalculationNode",
+        "process.calculation.calcfunction = aiida.orm.nodes.process.calculation.calcfunction:CalcFunctionNode",
+        "process.calculation.calcjob = aiida.orm.nodes.process.calculation.calcjob:CalcJobNode",
+        "process.workflow = aiida.orm.nodes.process.workflow.workflow:WorkflowNode",
+        "process.workflow.workchain = aiida.orm.nodes.process.workflow.workchain:WorkChainNode",
+        "process.workflow.workfunction = aiida.orm.nodes.process.workflow.workfunction:WorkFunctionNode"
+      ],
+      "aiida.parsers": [
+        "arithmetic.add = aiida.parsers.plugins.arithmetic.add:ArithmeticAddParser",
+        "templatereplacer.doubler = aiida.parsers.plugins.templatereplacer.doubler:TemplatereplacerDoublerParser"
+      ],
+      "aiida.schedulers": [
+        "direct = aiida.schedulers.plugins.direct:DirectScheduler",
+        "lsf = aiida.schedulers.plugins.lsf:LsfScheduler",
+        "pbspro = aiida.schedulers.plugins.pbspro:PbsproScheduler",
+        "sge = aiida.schedulers.plugins.sge:SgeScheduler",
+        "slurm = aiida.schedulers.plugins.slurm:SlurmScheduler",
+        "torque = aiida.schedulers.plugins.torque:TorqueScheduler"
+      ],
+      "aiida.transports": [
+        "local = aiida.transports.plugins.local:LocalTransport",
+        "ssh = aiida.transports.plugins.ssh:SshTransport"
+      ],
+      "aiida.tools.calculations": [],
+      "aiida.tools.dbexporters": [],
+      "aiida.tools.dbimporters": [
+        "cod = aiida.tools.dbimporters.plugins.cod:CodDbImporter",
+        "icsd = aiida.tools.dbimporters.plugins.icsd:IcsdDbImporter",
+        "materialsproject = aiida.tools.dbimporters.plugins.materialsproject:MaterialsProjectImporter",
+        "mpds = aiida.tools.dbimporters.plugins.mpds:MpdsDbImporter",
+        "mpod = aiida.tools.dbimporters.plugins.mpod:MpodDbImporter",
+        "nninc = aiida.tools.dbimporters.plugins.nninc:NnincDbImporter",
+        "oqmd = aiida.tools.dbimporters.plugins.oqmd:OqmdDbImporter",
+        "pcod = aiida.tools.dbimporters.plugins.pcod:PcodDbImporter",
+        "tcod = aiida.tools.dbimporters.plugins.tcod:TcodDbImporter"
+      ],
+      "aiida.tools.data.orbitals": [
+        "orbital = aiida.tools.data.orbital.orbital:Orbital",
+        "realhydrogen = aiida.tools.data.orbital.realhydrogen:RealhydrogenOrbital"
+      ],
+      "aiida.workflows": []
+    },
+    "metadata": {
+      "author": "The AiiDA team",
+      "author_email": "developers@aiida.net",
+      "version": "1.0.0",
+      "description": "",
+      "classifiers": [
+        "Framework :: AiiDA",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: POSIX :: Linux",
+        "Operating System :: MacOS :: MacOS X",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering"
+      ]
+    },
+    "aiida_version": null
+  },
+  "cp2k": {
+    "name": "aiida-cp2k",
+    "entry_point": "cp2k",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "version": "1.0.0b4",
+        "name": "aiida_cp2k",
+        "url": "https://github.com/aiidateam/aiida-cp2k",
+        "license": "MIT License",
+        "author": "Ole Sch\u00fctt, Edward Ditler, Aliaksandr Yakutovich, Patrick Seewald, Tiziano M\u00fcller, Andreas Gl\u00f6ss, Leonid Kahle",
+        "author_email": "ole.schuett@cp2k.org",
+        "description": "The CP2K plugin for the AiiDA workflow and provenance engine.",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Development Status :: 4 - Beta"
+        ],
+        "install_requires": [
+          "aiida-core>=1.0.0b5",
+          "ase==3.17.0; python_version<'3.0'",
+          "ase; python_version>='3.5'"
+        ],
+        "entry_points": {
+          "aiida.calculations": [
+            "cp2k = aiida_cp2k.calculations:Cp2kCalculation"
+          ],
+          "aiida.parsers": [
+            "cp2k_base_parser = aiida_cp2k.parsers:Cp2kBaseParser",
+            "cp2k_advanced_parser = aiida_cp2k.parsers:Cp2kAdvancedParser"
+          ],
+          "aiida.workflows": [
+            "cp2k.base = aiida_cp2k.workchains:Cp2kBaseWorkChain",
+            "cp2k.multistage= aiida_cp2k.workchains:Cp2kMultistageWorkChain"
+          ]
+        },
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "data_files": [
+          [
+            ".",
+            [
+              "setup.json"
+            ]
+          ]
+        ],
+        "extras_require": {
+          "test": [
+            "pytest==4.4.1"
+          ],
+          "pre-commit": [
+            "pre-commit==1.17.0",
+            "yapf==0.28.0",
+            "prospector==1.1.7",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.3.1; python_version>='3.0'"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/cp2k/aiida-cp2k",
+    "pip_url": "aiida-cp2k",
+    "package_name": "aiida_cp2k",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "cp2k = aiida_cp2k.calculations:Cp2kCalculation"
+      ],
+      "aiida.parsers": [
+        "cp2k_base_parser = aiida_cp2k.parsers:Cp2kBaseParser",
+        "cp2k_advanced_parser = aiida_cp2k.parsers:Cp2kAdvancedParser"
+      ],
+      "aiida.workflows": [
+        "cp2k.base = aiida_cp2k.workchains:Cp2kBaseWorkChain",
+        "cp2k.multistage= aiida_cp2k.workchains:Cp2kMultistageWorkChain"
+      ]
+    },
+    "metadata": {
+      "author": "Ole Sch\u00fctt, Edward Ditler, Aliaksandr Yakutovich, Patrick Seewald, Tiziano M\u00fcller, Andreas Gl\u00f6ss, Leonid Kahle",
+      "author_email": "ole.schuett@cp2k.org",
+      "version": "1.0.0b4",
+      "description": "The CP2K plugin for the AiiDA workflow and provenance engine.",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Development Status :: 4 - Beta"
+      ]
+    },
+    "aiida_version": ">=1.0.0b5"
+  },
+  "crystal17": {
+    "name": "aiida-crystal17",
+    "entry_point": "crystal17",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-crystal17",
+        "author": "Chris Sewell",
+        "author_email": "chrisj_sewell@hotmail.com",
+        "description": "AiiDA plugin for running the CRYSTAL17 code",
+        "url": "https://github.com/chrisjsewell/aiida-crystal17",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Topic :: Scientific/Engineering :: Chemistry",
+          "Topic :: Scientific/Engineering :: Physics",
+          "Framework :: AiiDA"
+        ],
+        "version": "0.10.0b5",
+        "entry_points": {
+          "console_scripts": [
+            "mock_crystal17 = aiida_crystal17.tests.mock_crystal17:main",
+            "mock_properties17 = aiida_crystal17.tests.mock_properties17:main",
+            "mock_gulp = aiida_crystal17.tests.mock_gulp:main"
+          ],
+          "aiida.data": [
+            "crystal17.parameters = aiida_crystal17.data.input_params:CryInputParamsData",
+            "crystal17.basisset = aiida_crystal17.data.basis_set:BasisSetData",
+            "crystal17.symmetry = aiida_crystal17.data.symmetry:SymmetryData",
+            "crystal17.kinds = aiida_crystal17.data.kinds:KindData",
+            "crystal17.gcube = aiida_crystal17.data.gcube:GaussianCube",
+            "gulp.potential = aiida_crystal17.gulp.data.potential:EmpiricalPotential"
+          ],
+          "aiida.calculations": [
+            "crystal17.basic = aiida_crystal17.calculations.cry_basic:CryBasicCalculation",
+            "crystal17.main = aiida_crystal17.calculations.cry_main:CryMainCalculation",
+            "crystal17.doss = aiida_crystal17.calculations.prop_doss:CryDossCalculation",
+            "crystal17.ech3 = aiida_crystal17.calculations.prop_ech3:CryEch3Calculation",
+            "crystal17.newk = aiida_crystal17.calculations.prop_newk:CryNewkCalculation",
+            "gulp.single = aiida_crystal17.gulp.calculations.gulp_single:GulpSingleCalculation",
+            "gulp.optimize = aiida_crystal17.gulp.calculations.gulp_optimize:GulpOptCalculation",
+            "gulp.fitting = aiida_crystal17.gulp.calculations.gulp_fitting:GulpFittingCalculation"
+          ],
+          "aiida.parsers": [
+            "crystal17.main = aiida_crystal17.parsers.cry_main:CryMainParser",
+            "crystal17.doss = aiida_crystal17.parsers.cry_doss:CryDossParser",
+            "crystal17.ech3 = aiida_crystal17.parsers.cry_ech3:CryEch3Parser",
+            "crystal17.newk = aiida_crystal17.parsers.cry_newk:CryNewkParser",
+            "gulp.single = aiida_crystal17.gulp.parsers.parse_single:GulpSingleParser",
+            "gulp.optimize = aiida_crystal17.gulp.parsers.parse_opt:GulpOptParser",
+            "gulp.fitting = aiida_crystal17.gulp.parsers.parse_fitting:GulpFittingParser"
+          ],
+          "aiida.workflows": [
+            "crystal17.sym3d = aiida_crystal17.workflows.symmetrise_3d_struct:Symmetrise3DStructure",
+            "crystal17.main.base = aiida_crystal17.workflows.crystal_main.base:CryMainBaseWorkChain",
+            "crystal17.properties = aiida_crystal17.workflows.crystal_props.base:CryPropertiesWorkChain"
+          ],
+          "aiida.cmdline.data": [
+            "crystal17.symmetry = aiida_crystal17.cmndline.symmetry:symmetry",
+            "crystal17.basis = aiida_crystal17.cmndline.basis_set:basisset",
+            "crystal17.parse = aiida_crystal17.cmndline.cmd_parser:parse",
+            "gulp.potentials = aiida_crystal17.gulp.cmndline.potentials:potentials"
+          ],
+          "gulp.potentials": [
+            "reaxff = aiida_crystal17.gulp.potentials.reaxff:PotentialWriterReaxff",
+            "lj =  aiida_crystal17.gulp.potentials.lj:PotentialWriterLJ"
+          ]
+        },
+        "include_package_data": true,
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core==1.0.0b5",
+          "six >=1.12.0",
+          "ruamel.yaml",
+          "jsonextended>=0.7.10",
+          "jsonschema",
+          "spglib>=1.10.0,<2.0.0",
+          "ase>=3.12.0,<3.18.0; python_version < '3'",
+          "ase>=3.12.0,<4.0.0; python_version >= '3'",
+          "PyCifRW==4.2.1; python_version < '3'",
+          "PyCifRW==4.4; python_version >= '3'",
+          "pathlib2; python_version < '3.4'",
+          "importlib_resources"
+        ],
+        "extras_require": {
+          "testing": [
+            "mock==2.0.0",
+            "pgtest==1.2.0",
+            "sqlalchemy-diff==0.1.3",
+            "pytest==3.6.3",
+            "wheel>=0.31",
+            "coverage",
+            "pytest-cov",
+            "pytest-timeout",
+            "pytest-regressions",
+            "pytest-notebook; python_version >= '3.5'"
+          ],
+          "code_style": [
+            "flake8<3.8.0,>=3.7.0",
+            "yapf==0.28.0",
+            "pre-commit==1.17.0",
+            "doc8<0.9.0,>=0.8.0"
+          ],
+          "docs": [
+            "sphinx>=1.6",
+            "ipypublish>=0.10.7"
+          ]
+        }
+      }
+    ],
+    "documentation_url": "https://aiida-crystal17.readthedocs.io",
+    "code_home": "https://github.com/chrisjsewell/aiida-crystal17",
+    "pip_url": "aiida-crystal17",
+    "package_name": "aiida_crystal17",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "console_scripts": [
+        "mock_crystal17 = aiida_crystal17.tests.mock_crystal17:main",
+        "mock_properties17 = aiida_crystal17.tests.mock_properties17:main",
+        "mock_gulp = aiida_crystal17.tests.mock_gulp:main"
+      ],
+      "aiida.data": [
+        "crystal17.parameters = aiida_crystal17.data.input_params:CryInputParamsData",
+        "crystal17.basisset = aiida_crystal17.data.basis_set:BasisSetData",
+        "crystal17.symmetry = aiida_crystal17.data.symmetry:SymmetryData",
+        "crystal17.kinds = aiida_crystal17.data.kinds:KindData",
+        "crystal17.gcube = aiida_crystal17.data.gcube:GaussianCube",
+        "gulp.potential = aiida_crystal17.gulp.data.potential:EmpiricalPotential"
+      ],
+      "aiida.calculations": [
+        "crystal17.basic = aiida_crystal17.calculations.cry_basic:CryBasicCalculation",
+        "crystal17.main = aiida_crystal17.calculations.cry_main:CryMainCalculation",
+        "crystal17.doss = aiida_crystal17.calculations.prop_doss:CryDossCalculation",
+        "crystal17.ech3 = aiida_crystal17.calculations.prop_ech3:CryEch3Calculation",
+        "crystal17.newk = aiida_crystal17.calculations.prop_newk:CryNewkCalculation",
+        "gulp.single = aiida_crystal17.gulp.calculations.gulp_single:GulpSingleCalculation",
+        "gulp.optimize = aiida_crystal17.gulp.calculations.gulp_optimize:GulpOptCalculation",
+        "gulp.fitting = aiida_crystal17.gulp.calculations.gulp_fitting:GulpFittingCalculation"
+      ],
+      "aiida.parsers": [
+        "crystal17.main = aiida_crystal17.parsers.cry_main:CryMainParser",
+        "crystal17.doss = aiida_crystal17.parsers.cry_doss:CryDossParser",
+        "crystal17.ech3 = aiida_crystal17.parsers.cry_ech3:CryEch3Parser",
+        "crystal17.newk = aiida_crystal17.parsers.cry_newk:CryNewkParser",
+        "gulp.single = aiida_crystal17.gulp.parsers.parse_single:GulpSingleParser",
+        "gulp.optimize = aiida_crystal17.gulp.parsers.parse_opt:GulpOptParser",
+        "gulp.fitting = aiida_crystal17.gulp.parsers.parse_fitting:GulpFittingParser"
+      ],
+      "aiida.workflows": [
+        "crystal17.sym3d = aiida_crystal17.workflows.symmetrise_3d_struct:Symmetrise3DStructure",
+        "crystal17.main.base = aiida_crystal17.workflows.crystal_main.base:CryMainBaseWorkChain",
+        "crystal17.properties = aiida_crystal17.workflows.crystal_props.base:CryPropertiesWorkChain"
+      ],
+      "aiida.cmdline.data": [
+        "crystal17.symmetry = aiida_crystal17.cmndline.symmetry:symmetry",
+        "crystal17.basis = aiida_crystal17.cmndline.basis_set:basisset",
+        "crystal17.parse = aiida_crystal17.cmndline.cmd_parser:parse",
+        "gulp.potentials = aiida_crystal17.gulp.cmndline.potentials:potentials"
+      ],
+      "gulp.potentials": [
+        "reaxff = aiida_crystal17.gulp.potentials.reaxff:PotentialWriterReaxff",
+        "lj =  aiida_crystal17.gulp.potentials.lj:PotentialWriterLJ"
+      ]
+    },
+    "metadata": {
+      "author": "Chris Sewell",
+      "author_email": "chrisj_sewell@hotmail.com",
+      "version": "0.10.0b5",
+      "description": "AiiDA plugin for running the CRYSTAL17 code",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Chemistry",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": "==1.0.0b5"
+  },
+  "ddec": {
+    "name": "aiida-ddec",
+    "entry_point": "ddec",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-ddec",
+        "author": "Aliaksandr Yakutovich",
+        "author_email": "aliaksandr.yakutovich@epfl.ch",
+        "description": "AiiDA plugin DDEC code",
+        "url": "https://github.com/yakutovicha/aiida-ddec",
+        "license": "MIT License",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Development Status :: 2 - Pre-Alpha"
+        ],
+        "version": "1.0.0a1",
+        "entry_points": {
+          "aiida.calculations": [
+            "ddec = aiida_ddec.calculations:DdecCalculation"
+          ],
+          "aiida.parsers": [
+            "ddec = aiida_ddec.parsers:DdecParser"
+          ],
+          "aiida.workflows": [
+            "ddec.cp2k_ddec = aiida_ddec.workchains:Cp2kDdecWorkChain"
+          ]
+        },
+        "setup_requires": [
+          "reentry"
+        ],
+        "data_files": [
+          [
+            ".",
+            [
+              "setup.json"
+            ]
+          ]
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida_core >= 1.0.0b6",
+          "six"
+        ],
+        "extras_require": {
+          "cp2k": [
+            "aiida-cp2k>=1.0.0b4"
+          ],
+          "pre-commit": [
+            "pre-commit==1.17.0",
+            "yapf==0.28.0",
+            "prospector==1.1.7",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.3.1; python_version>='3.0'"
+          ],
+          "testing": [
+            "pytest==4.4.1"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/yakutovicha/aiida-ddec",
+    "pip_url": "git+https://github.com/yakutovicha/aiida-ddec",
+    "package_name": "aiida_ddec",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "ddec = aiida_ddec.calculations:DdecCalculation"
+      ],
+      "aiida.parsers": [
+        "ddec = aiida_ddec.parsers:DdecParser"
+      ],
+      "aiida.workflows": [
+        "ddec.cp2k_ddec = aiida_ddec.workchains:Cp2kDdecWorkChain"
+      ]
+    },
+    "metadata": {
+      "author": "Aliaksandr Yakutovich",
+      "author_email": "aliaksandr.yakutovich@epfl.ch",
+      "version": "1.0.0a1",
+      "description": "AiiDA plugin DDEC code",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Development Status :: 2 - Pre-Alpha"
+      ]
+    },
+    "aiida_version": ">=1.0.0b6"
+  },
+  "diff": {
+    "name": "aiida-diff",
+    "entry_point": "diff",
+    "state": "stable",
+    "pip_url": "git+https://github.com/aiidateam/aiida-diff#egg=aiida-diff-0.1.0a0",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-diff",
+        "author": "The AiiDA Team",
+        "author_email": "",
+        "description": "AiiDA demo plugin that wraps the `diff` executable for computing the difference between two files.",
+        "url": "https://github.com/aiidateam/aiida-diff",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: MIT License",
+          "Natural Language :: English",
+          "Framework :: AiiDA"
+        ],
+        "version": "1.0.0",
+        "entry_points": {
+          "aiida.data": [
+            "diff = aiida_diff.data:DiffParameters"
+          ],
+          "aiida.calculations": [
+            "diff = aiida_diff.calculations:DiffCalculation"
+          ],
+          "aiida.parsers": [
+            "diff = aiida_diff.parsers:DiffParser"
+          ],
+          "aiida.cmdline.data": [
+            "diff = aiida_diff.cli:data_cli"
+          ]
+        },
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0,<2.0.0",
+          "six",
+          "voluptuous"
+        ],
+        "extras_require": {
+          "testing": [
+            "pgtest==1.3.1",
+            "wheel>=0.31",
+            "coverage",
+            "pytest>=3.6.3,<5.0.0",
+            "pytest-cov>=2.6.1,<5.0.0"
+          ],
+          "pre-commit": [
+            "astroid==1.6.6; python_version<'3.0'",
+            "astroid==2.2.5; python_version>='3.0'",
+            "pre-commit==1.20.0",
+            "prospector==1.1.7",
+            "pylint-django<0.9; python_version<'3.0'",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.3.1; python_version>='3.0'"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-diff",
+    "documentation_url": "https://aiida-diff.readthedocs.io/",
+    "package_name": "aiida_diff",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.data": [
+        "diff = aiida_diff.data:DiffParameters"
+      ],
+      "aiida.calculations": [
+        "diff = aiida_diff.calculations:DiffCalculation"
+      ],
+      "aiida.parsers": [
+        "diff = aiida_diff.parsers:DiffParser"
+      ],
+      "aiida.cmdline.data": [
+        "diff = aiida_diff.cli:data_cli"
+      ]
+    },
+    "metadata": {
+      "author": "The AiiDA Team",
+      "author_email": "",
+      "version": "1.0.0",
+      "description": "AiiDA demo plugin that wraps the `diff` executable for computing the difference between two files.",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0,<2.0.0"
+  },
+  "fleur": {
+    "name": "aiida-fleur",
+    "entry_point": "fleur",
+    "state": "development",
+    "pip_url": "aiida-fleur",
+    "plugin_info": [
+      "setuptools",
+      {
+        "version": "1.0.0a",
+        "name": "aiida-fleur",
+        "url": "https://github.com/JuDFTteam/aiida-fleur",
+        "license": "MIT License, see LICENSE.txt file.",
+        "author": "JuDFTteam",
+        "author_email": "j.broeder@fz-juelich.de",
+        "description": "Python FLEUR simulation package containing an AiiDA Plugin for running the FLEUR-code and its input generator. Plus some workflows and utility",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.4",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
+          "Development Status :: 4 - Beta",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "Topic :: Scientific/Engineering :: Physics",
+          "Natural Language :: English"
+        ],
+        "keywords": "fleur aiida inpgen workflows flapw juelich dft all-electron",
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core >= 1.0.0b1[atomic_tools]",
+          "lxml >= 3.6.4",
+          "pytest-cov >= 2.5.0",
+          "pytest >= 2.9",
+          "pgtest",
+          "numpy>=1.16.0",
+          "sympy",
+          "masci-tools",
+          "future",
+          "ase",
+          "pymatgen"
+        ],
+        "extras_require": {
+          "graphs ": [
+            "matplotlib",
+            "masci-tools"
+          ],
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.24.0",
+            "prospector==0.12.11",
+            "pylint==1.9.3"
+          ]
+        },
+        "entry_points": {
+          "aiida.calculations": [
+            "fleur.fleur = aiida_fleur.calculation.fleur:FleurCalculation",
+            "fleur.inpgen = aiida_fleur.calculation.fleurinputgen:FleurinputgenCalculation"
+          ],
+          "aiida.data": [
+            "fleur.fleurinp = aiida_fleur.data.fleurinp:FleurinpData",
+            "fleur.fleurinpmodifier = aiida_fleur.data.fleurinpmodifier:FleurinpModifier"
+          ],
+          "aiida.parsers": [
+            "fleur.fleurparser = aiida_fleur.parsers.fleur:FleurParser",
+            "fleur.fleurinpgenparser = aiida_fleur.parsers.fleur_inputgen:Fleur_inputgenParser"
+          ],
+          "aiida.workflows": [
+            "fleur.scf = aiida_fleur.workflows.scf:FleurScfWorkChain",
+            "fleur.dos = aiida_fleur.workflows.dos:fleur_dos_wc",
+            "fleur.band = aiida_fleur.workflows.band:fleur_band_wc",
+            "fleur.eos = aiida_fleur.workflows.eos:FleurEosWorkChain",
+            "fleur.init_cls = aiida_fleur.workflows.initial_cls:fleur_initial_cls_wc",
+            "fleur.corehole = aiida_fleur.workflows.corehole:fleur_corehole_wc",
+            "fleur.mae = aiida_fleur.workflows.mae:FleurMaeWorkChain",
+            "fleur.mae_conv = aiida_fleur.workflows.mae_conv:FleurMaeConvWorkChain",
+            "fleur.ssdisp = aiida_fleur.workflows.ssdisp:FleurSSDispWorkChain",
+            "fleur.ssdisp_conv = aiida_fleur.workflows.ssdisp_conv:FleurSSDispConvWorkChain",
+            "fleur.dmi = aiida_fleur.workflows.dmi:FleurDMIWorkChain",
+            "fleur.relax = aiida_fleur.workflows.relax:FleurRelaxWorkChain",
+            "fleur.base = aiida_fleur.workflows.base_fleur:FleurBaseWorkChain"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/JuDFTteam/aiida-fleur/tree/develop",
+    "documentation_url": "https://aiida-fleur.readthedocs.io/",
+    "package_name": "aiida_fleur",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "fleur.fleur = aiida_fleur.calculation.fleur:FleurCalculation",
+        "fleur.inpgen = aiida_fleur.calculation.fleurinputgen:FleurinputgenCalculation"
+      ],
+      "aiida.data": [
+        "fleur.fleurinp = aiida_fleur.data.fleurinp:FleurinpData",
+        "fleur.fleurinpmodifier = aiida_fleur.data.fleurinpmodifier:FleurinpModifier"
+      ],
+      "aiida.parsers": [
+        "fleur.fleurparser = aiida_fleur.parsers.fleur:FleurParser",
+        "fleur.fleurinpgenparser = aiida_fleur.parsers.fleur_inputgen:Fleur_inputgenParser"
+      ],
+      "aiida.workflows": [
+        "fleur.scf = aiida_fleur.workflows.scf:FleurScfWorkChain",
+        "fleur.dos = aiida_fleur.workflows.dos:fleur_dos_wc",
+        "fleur.band = aiida_fleur.workflows.band:fleur_band_wc",
+        "fleur.eos = aiida_fleur.workflows.eos:FleurEosWorkChain",
+        "fleur.init_cls = aiida_fleur.workflows.initial_cls:fleur_initial_cls_wc",
+        "fleur.corehole = aiida_fleur.workflows.corehole:fleur_corehole_wc",
+        "fleur.mae = aiida_fleur.workflows.mae:FleurMaeWorkChain",
+        "fleur.mae_conv = aiida_fleur.workflows.mae_conv:FleurMaeConvWorkChain",
+        "fleur.ssdisp = aiida_fleur.workflows.ssdisp:FleurSSDispWorkChain",
+        "fleur.ssdisp_conv = aiida_fleur.workflows.ssdisp_conv:FleurSSDispConvWorkChain",
+        "fleur.dmi = aiida_fleur.workflows.dmi:FleurDMIWorkChain",
+        "fleur.relax = aiida_fleur.workflows.relax:FleurRelaxWorkChain",
+        "fleur.base = aiida_fleur.workflows.base_fleur:FleurBaseWorkChain"
+      ]
+    },
+    "metadata": {
+      "author": "JuDFTteam",
+      "author_email": "j.broeder@fz-juelich.de",
+      "version": "1.0.0a",
+      "description": "Python FLEUR simulation package containing an AiiDA Plugin for running the FLEUR-code and its input generator. Plus some workflows and utility",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Development Status :: 4 - Beta",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Natural Language :: English"
+      ]
+    },
+    "aiida_version": ">=1.0.0b1[atomic_tools]"
+  },
+  "gaussian-datatypes": {
+    "name": "aiida-gaussian-datatypes",
+    "entry_point": "gaussian",
+    "state": "development",
+    "pip_url": "aiida-gaussian-datatypes",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-gaussian-datatypes",
+        "author": "Tiziano M\u00fcller",
+        "author_email": "tiziano.mueller@chem.uzh.ch",
+        "description": "AiiDA data plugin to manage gaussian datatypes (basis sets and pseudopotentials) as first-class citizens",
+        "url": "https://github.com/dev-zero/aiida-gaussian-datatypes",
+        "license": "MIT License",
+        "classifiers": [
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Development Status :: 4 - Beta",
+          "License :: OSI Approved :: MIT License",
+          "Operating System :: OS Independent",
+          "Topic :: Software Development :: Libraries :: Python Modules",
+          "Topic :: Scientific/Engineering :: Chemistry",
+          "Intended Audience :: Science/Research"
+        ],
+        "version": "0.3.0",
+        "entry_points": {
+          "aiida.data": [
+            "gaussian.basisset = aiida_gaussian_datatypes.basisset.data:BasisSet",
+            "gaussian.pseudo = aiida_gaussian_datatypes.pseudopotential.data:Pseudopotential"
+          ],
+          "aiida.cmdline.data": [
+            "gaussian.basisset = aiida_gaussian_datatypes.basisset.cli:cli",
+            "gaussian.pseudo = aiida_gaussian_datatypes.pseudopotential.cli:cli"
+          ]
+        },
+        "scripts": [],
+        "reentry_register": true,
+        "install_requires": [
+          "voluptuous >= 0.11.7",
+          "aiida-core >= 1.0.0b6"
+        ],
+        "extras_require": {
+          "testing": [
+            "pytest >= 5.1.2",
+            "pytest-cov >= 2.7.1",
+            "codecov >= 2.0.15",
+            "pgtest >= 1.2.0"
+          ],
+          "pre-commit": [
+            "pre-commit >= 1.18.3"
+          ],
+          "docs": [
+            "sphinx >= 2.1.0,<2.2.0",
+            "sphinx-click >= 2.2.0"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/dev-zero/aiida-gaussian-datatypes",
+    "documentation_url": "https://github.com/dev-zero/aiida-gaussian-datatypes/blob/master/README.md",
+    "package_name": "aiida_gaussian_datatypes",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.data": [
+        "gaussian.basisset = aiida_gaussian_datatypes.basisset.data:BasisSet",
+        "gaussian.pseudo = aiida_gaussian_datatypes.pseudopotential.data:Pseudopotential"
+      ],
+      "aiida.cmdline.data": [
+        "gaussian.basisset = aiida_gaussian_datatypes.basisset.cli:cli",
+        "gaussian.pseudo = aiida_gaussian_datatypes.pseudopotential.cli:cli"
+      ]
+    },
+    "metadata": {
+      "author": "Tiziano M\u00fcller",
+      "author_email": "tiziano.mueller@chem.uzh.ch",
+      "version": "0.3.0",
+      "description": "AiiDA data plugin to manage gaussian datatypes (basis sets and pseudopotentials) as first-class citizens",
+      "classifiers": [
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Development Status :: 4 - Beta",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+        "Topic :: Scientific/Engineering :: Chemistry",
+        "Intended Audience :: Science/Research"
+      ]
+    },
+    "aiida_version": ">=1.0.0b6"
+  },
+  "gollum": {
+    "name": "aiida-gollum",
+    "entry_point": "gollum",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "version": "0.12.0",
+        "name": "aiida_gollum",
+        "url": "https://github.com/garsua/aiida-gollum",
+        "download_url": "https://github.com/garsua/aiida-gollum.git",
+        "keywords": [
+          "aiida",
+          "gollum",
+          "transport"
+        ],
+        "license": "MIT License",
+        "author": "Victor M. Garcia-Suarez",
+        "author_email": "vm.garcia@cinn.es",
+        "description": "A plugin for Gollum functionality within AiiDA framework.",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Development Status :: 1 - Alpha"
+        ],
+        "install_requires": [
+          "aiida_core[docs,atomic_tools]>=0.12.0",
+          "pytest>=3.3.2"
+        ],
+        "entry_points": {
+          "aiida.calculations": [
+            "gollum.gollum = aiida_gollum.calculations.gollum:GollumCalculation"
+          ],
+          "aiida.parsers": [
+            "gollum.parser = aiida_gollum.parsers.gollum:GollumParser"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/garsua/aiida-gollum/",
+    "documentation_url": "https://aiida-gollum.readthedocs.io/",
+    "pip_url": "git+https://github.com/garsua/aiida-gollum",
+    "package_name": "aiida_gollum",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "gollum.gollum = aiida_gollum.calculations.gollum:GollumCalculation"
+      ],
+      "aiida.parsers": [
+        "gollum.parser = aiida_gollum.parsers.gollum:GollumParser"
+      ]
+    },
+    "metadata": {
+      "author": "Victor M. Garcia-Suarez",
+      "author_email": "vm.garcia@cinn.es",
+      "version": "0.12.0",
+      "description": "A plugin for Gollum functionality within AiiDA framework.",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Development Status :: 1 - Alpha"
+      ]
+    },
+    "aiida_version": ">=0.12.0"
+  },
+  "graphql": {
+    "name": "aiida-graphql",
+    "entry_point": "graphql",
+    "state": "development",
+    "code_home": "https://github.com/dev-zero/aiida-graphql",
+    "plugin_info": [
+      "poetry",
+      {
+        "tool": {
+          "poetry": {
+            "name": "aiida-graphql",
+            "version": "0.0.2",
+            "description": "Strawberry-based GraphQL API Server for AiiDA",
+            "authors": [
+              "Tiziano M\u00fcller <tiziano.mueller@chem.uzh.ch>"
+            ],
+            "repository": "https://github.com/dev-zero/aiida-graphql",
+            "license": "MIT",
+            "classifiers": [
+              "Development Status :: 3 - Alpha",
+              "License :: OSI Approved :: MIT License",
+              "Operating System :: OS Independent",
+              "Topic :: Software Development :: Libraries :: Python Modules",
+              "Intended Audience :: Science/Research"
+            ],
+            "readme": "README.md",
+            "dependencies": {
+              "python": "^3.7",
+              "aiida": "^1.0.0b6",
+              "strawberry-graphql": "^0.16.7"
+            },
+            "dev-dependencies": {
+              "pytest": "^5.2",
+              "codecov": "^2.0.15",
+              "pytest-cov": "^2.7.1"
+            }
+          },
+          "black": {
+            "line-length": 132,
+            "target_version": [
+              "py37"
+            ]
+          }
+        },
+        "build-system": {
+          "requires": [
+            "poetry>=0.12"
+          ],
+          "build-backend": "poetry.masonry.api"
+        }
+      }
+    ],
+    "pip_url": "aiida-graphql",
+    "package_name": "aiida_graphql",
+    "hosted_on": "github.com",
+    "entry_points": {},
+    "metadata": {
+      "version": "0.0.2",
+      "description": "Strawberry-based GraphQL API Server for AiiDA",
+      "author": "Tiziano M\u00fcller"
+    },
+    "aiida_version": ">=1.0.0b6,<2.0.0"
+  },
+  "gudhi": {
+    "name": "aiida-gudhi",
+    "entry_point": "gudhi",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-gudhi",
+        "author": "Leopold Talirz",
+        "author_email": "leopold.talirz@gmail.com",
+        "description": "AiiDA plugin for the [GUDHI](http://gudhi.gforge.inria.fr/) library for topological data analysis.",
+        "url": "https://github.com/ltalirz/aiida-gudhi",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python"
+        ],
+        "version": "0.1.0a3",
+        "entry_points": {
+          "aiida.calculations": [
+            "gudhi.rdm = aiida_gudhi.calculations.rips:RipsDistanceMatrixCalculation"
+          ],
+          "aiida.parsers": [
+            "gudhi.rdm = aiida_gudhi.parsers.rips:RipsParser"
+          ],
+          "aiida.data": [
+            "gudhi.rdm = aiida_gudhi.data.rips:RipsDistanceMatrixParameters"
+          ]
+        },
+        "scripts": [
+          "examples/cli.py"
+        ],
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida >= 0.11"
+        ],
+        "extras_require": {
+          "testing": [
+            "aiida-core[testing]"
+          ],
+          "pre-commit": [
+            "pre-commit",
+            "yapf",
+            "prospector",
+            "pylint"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/ltalirz/aiida-gudhi",
+    "pip_url": "aiida-gudhi",
+    "package_name": "aiida_gudhi",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "gudhi.rdm = aiida_gudhi.calculations.rips:RipsDistanceMatrixCalculation"
+      ],
+      "aiida.parsers": [
+        "gudhi.rdm = aiida_gudhi.parsers.rips:RipsParser"
+      ],
+      "aiida.data": [
+        "gudhi.rdm = aiida_gudhi.data.rips:RipsDistanceMatrixParameters"
+      ]
+    },
+    "metadata": {
+      "author": "Leopold Talirz",
+      "author_email": "leopold.talirz@gmail.com",
+      "version": "0.1.0a3",
+      "description": "AiiDA plugin for the [GUDHI](http://gudhi.gforge.inria.fr/) library for topological data analysis.",
+      "classifiers": [
+        "Programming Language :: Python"
+      ]
+    },
+    "aiida_version": ">=0.11"
+  },
+  "gulp": {
+    "name": "aiida-gulp",
+    "entry_point": "gulp",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-gulp",
+        "author": "Chris Sewell",
+        "author_email": "chrisj_sewell@hotmail.com",
+        "description": "AiiDA plugin for running the GULP MD code",
+        "url": "https://github.com/chrisjsewell/aiida-gulp",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Topic :: Scientific/Engineering :: Chemistry",
+          "Topic :: Scientific/Engineering :: Physics",
+          "Framework :: AiiDA"
+        ],
+        "version": "0.10.0b5",
+        "entry_points": {
+          "console_scripts": [
+            "gulp_mock = aiida_gulp.tests.mock_gulp:main"
+          ],
+          "aiida.data": [
+            "gulp.symmetry = aiida_gulp.data.symmetry:SymmetryData",
+            "gulp.potential = aiida_gulp.data.potential:EmpiricalPotential"
+          ],
+          "aiida.calculations": [
+            "gulp.single = aiida_gulp.calculations.gulp_single:GulpSingleCalculation",
+            "gulp.optimize = aiida_gulp.calculations.gulp_optimize:GulpOptCalculation",
+            "gulp.fitting = aiida_gulp.calculations.gulp_fitting:GulpFittingCalculation"
+          ],
+          "aiida.parsers": [
+            "gulp.single = aiida_gulp.parsers.parse_single:GulpSingleParser",
+            "gulp.optimize = aiida_gulp.parsers.parse_opt:GulpOptParser",
+            "gulp.fitting = aiida_gulp.parsers.parse_fitting:GulpFittingParser"
+          ],
+          "aiida.workflows": [],
+          "aiida.cmdline.data": [
+            "gulp.potentials = aiida_gulp.cmndline.potentials:potentials"
+          ],
+          "gulp.potentials": [
+            "reaxff = aiida_gulp.potentials.reaxff:PotentialWriterReaxff",
+            "lj =  aiida_gulp.potentials.lj:PotentialWriterLJ"
+          ]
+        },
+        "include_package_data": true,
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core==1.0.0b5",
+          "six >=1.12.0",
+          "ruamel.yaml",
+          "jsonextended>=0.7.10",
+          "jsonschema",
+          "spglib>=1.10.0,<2.0.0",
+          "ase>=3.12.0,<3.18.0; python_version < '3'",
+          "ase>=3.12.0,<4.0.0; python_version >= '3'",
+          "PyCifRW==4.2.1; python_version < '3'",
+          "PyCifRW==4.4; python_version >= '3'",
+          "pathlib2; python_version < '3.4'",
+          "importlib_resources"
+        ],
+        "extras_require": {
+          "testing": [
+            "mock==2.0.0",
+            "pgtest==1.2.0",
+            "sqlalchemy-diff==0.1.3",
+            "pytest==3.6.3",
+            "wheel>=0.31",
+            "coverage",
+            "pytest-cov",
+            "pytest-timeout",
+            "pytest-regressions",
+            "pytest-notebook; python_version >= '3.5'"
+          ],
+          "code_style": [
+            "black==19.3b0",
+            "flake8<3.8.0,>=3.7.0",
+            "pre-commit==1.17.0",
+            "doc8<0.9.0,>=0.8.0"
+          ],
+          "docs": [
+            "sphinx>=1.6",
+            "ipypublish>=0.10.7"
+          ]
+        }
+      }
+    ],
+    "documentation_url": "https://aiida-gulp.readthedocs.io",
+    "code_home": "https://github.com/chrisjsewell/aiida-gulp",
+    "pip_url": "aiida-gulp",
+    "package_name": "aiida_gulp",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "console_scripts": [
+        "gulp_mock = aiida_gulp.tests.mock_gulp:main"
+      ],
+      "aiida.data": [
+        "gulp.symmetry = aiida_gulp.data.symmetry:SymmetryData",
+        "gulp.potential = aiida_gulp.data.potential:EmpiricalPotential"
+      ],
+      "aiida.calculations": [
+        "gulp.single = aiida_gulp.calculations.gulp_single:GulpSingleCalculation",
+        "gulp.optimize = aiida_gulp.calculations.gulp_optimize:GulpOptCalculation",
+        "gulp.fitting = aiida_gulp.calculations.gulp_fitting:GulpFittingCalculation"
+      ],
+      "aiida.parsers": [
+        "gulp.single = aiida_gulp.parsers.parse_single:GulpSingleParser",
+        "gulp.optimize = aiida_gulp.parsers.parse_opt:GulpOptParser",
+        "gulp.fitting = aiida_gulp.parsers.parse_fitting:GulpFittingParser"
+      ],
+      "aiida.workflows": [],
+      "aiida.cmdline.data": [
+        "gulp.potentials = aiida_gulp.cmndline.potentials:potentials"
+      ],
+      "gulp.potentials": [
+        "reaxff = aiida_gulp.potentials.reaxff:PotentialWriterReaxff",
+        "lj =  aiida_gulp.potentials.lj:PotentialWriterLJ"
+      ]
+    },
+    "metadata": {
+      "author": "Chris Sewell",
+      "author_email": "chrisj_sewell@hotmail.com",
+      "version": "0.10.0b5",
+      "description": "AiiDA plugin for running the GULP MD code",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Chemistry",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": "==1.0.0b5"
+  },
+  "hea": {
+    "name": "aiida-hea",
+    "entry_point": "hea",
+    "state": "registered",
+    "code_home": "https://github.com/unkcpz/aiida-hea",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-hea",
+        "author": "Jason Eu",
+        "author_email": "morty.yu@yahoo.com",
+        "description": "AiiDA plugin for generating special quasi-random structures by ATAT/sqs and enumerating derivative superstructures by enumlib.",
+        "url": "https://github.com/unkcpz/aiida-hea",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: MIT License",
+          "Natural Language :: English",
+          "Framework :: AiiDA"
+        ],
+        "version": "0.1.0a0",
+        "entry_points": {
+          "aiida.data": [
+            "hea = aiida_hea.data:DiffParameters"
+          ],
+          "aiida.calculations": [
+            "hea = aiida_hea.calculations:DiffCalculation"
+          ],
+          "aiida.parsers": [
+            "hea = aiida_hea.parsers:DiffParser"
+          ],
+          "aiida.cmdline.data": [
+            "hea = aiida_hea.cli:data_cli"
+          ]
+        },
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0b3,<2.0.0",
+          "six",
+          "voluptuous"
+        ],
+        "extras_require": {
+          "testing": [
+            "pgtest==1.2.0",
+            "wheel>=0.31",
+            "coverage",
+            "pytest>=3.6.3,<5.0.0",
+            "pytest-cov>=2.6.1,<5.0.0"
+          ],
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.27.0",
+            "prospector==0.12.11",
+            "pylint==1.9.4"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "pip_url": "git+https://github.com/unkcpz/aiida-hea",
+    "documentation_url": "https://aiida-hea.readthedocs.io/",
+    "package_name": "aiida_hea",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.data": [
+        "hea = aiida_hea.data:DiffParameters"
+      ],
+      "aiida.calculations": [
+        "hea = aiida_hea.calculations:DiffCalculation"
+      ],
+      "aiida.parsers": [
+        "hea = aiida_hea.parsers:DiffParser"
+      ],
+      "aiida.cmdline.data": [
+        "hea = aiida_hea.cli:data_cli"
+      ]
+    },
+    "metadata": {
+      "author": "Jason Eu",
+      "author_email": "morty.yu@yahoo.com",
+      "version": "0.1.0a0",
+      "description": "AiiDA plugin for generating special quasi-random structures by ATAT/sqs and enumerating derivative superstructures by enumlib.",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0b3,<2.0.0"
+  },
+  "kkr": {
+    "name": "aiida-kkr",
+    "entry_point": "kkr",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-kkr",
+        "author": "Philipp Ruessmann, Jens Broeder, Fabian Bertoldo",
+        "author_email": "p.ruessmann@fz-juelich.de",
+        "description": "AiiDA plugin for the KKR code",
+        "url": "https://github.com/JuDFTteam/aiida-kkr",
+        "download_url": "https://github.com/JuDFTteam/aiida-kkr",
+        "license": "MIT",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.4",
+          "Programming Language :: Python :: 3.5",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Development Status :: 4 - Beta",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "Topic :: Scientific/Engineering :: Physics",
+          "Natural Language :: English",
+          "Framework :: AiiDA"
+        ],
+        "version": "1.1.9-dev",
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core >= 1.0.0b6,<2.0.0",
+          "masci-tools >= 0.3.10",
+          "seekpath >= 1.9.2",
+          "pgtest >= 1.3.0",
+          "pytest-cov >= 2.5.0",
+          "pytest-mpl>=0.10",
+          "pytest-timeout>=1.3.3",
+          "Sphinx==1.8.2",
+          "sphinx_rtd_theme==0.4.2",
+          "ase<=3.17.0",
+          "bump2version >= 0.5.10"
+        ],
+        "extras_require": {
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.24.0",
+            "prospector==0.12.11",
+            "pylint==1.9.3"
+          ]
+        },
+        "entry_points": {
+          "aiida.calculations": [
+            "kkr.kkr = aiida_kkr.calculations.kkr:KkrCalculation",
+            "kkr.kkrimporter = aiida_kkr.calculations.kkrimporter:KkrImporterCalculation",
+            "kkr.voro = aiida_kkr.calculations.voro:VoronoiCalculation",
+            "kkr.kkrimp = aiida_kkr.calculations.kkrimp:KkrimpCalculation"
+          ],
+          "aiida.parsers": [
+            "kkr.voroparser = aiida_kkr.parsers.voro:VoronoiParser",
+            "kkr.kkrparser = aiida_kkr.parsers.kkr:KkrParser",
+            "kkr.kkrimporterparser = aiida_kkr.parsers.kkrimporter:KkrImporterParser",
+            "kkr.kkrimpparser = aiida_kkr.parsers.kkrimp:KkrimpParser"
+          ],
+          "aiida.data": [
+            "kkr.kkrstructure = aiida_kkr.data.kkrstructure:KkrstructureData"
+          ],
+          "aiida.workflows": [
+            "kkr.scf = aiida_kkr.workflows.kkr_scf:kkr_scf_wc",
+            "kkr.dos = aiida_kkr.workflows.dos:kkr_dos_wc",
+            "kkr.eos = aiida_kkr.workflows.eos:kkr_eos_wc",
+            "kkr.startpot = aiida_kkr.workflows.voro_start:kkr_startpot_wc",
+            "kkr.check_mag = aiida_kkr.workflows.check_magnetic_state:kkr_check_mag_wc",
+            "kkr.convergence_check = aiida_kkr.workflows.check_para_convergence:kkr_check_para_wc",
+            "kkr.gf_writeout = aiida_kkr.workflows.gf_writeout:kkr_flex_wc",
+            "kkr.imp_sub = aiida_kkr.workflows.kkr_imp_sub:kkr_imp_sub_wc",
+            "kkr.imp = aiida_kkr.workflows.kkr_imp:kkr_imp_wc"
+          ],
+          "console_scripts": [
+            "kkrstructure = aiida_kkr.cmdline.data_cli:cli"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/JuDFTteam/aiida-kkr/tree/develop",
+    "documentation_url": "https://aiida-kkr.readthedocs.io/",
+    "pip_url": "aiida-kkr",
+    "package_name": "aiida_kkr",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "kkr.kkr = aiida_kkr.calculations.kkr:KkrCalculation",
+        "kkr.kkrimporter = aiida_kkr.calculations.kkrimporter:KkrImporterCalculation",
+        "kkr.voro = aiida_kkr.calculations.voro:VoronoiCalculation",
+        "kkr.kkrimp = aiida_kkr.calculations.kkrimp:KkrimpCalculation"
+      ],
+      "aiida.parsers": [
+        "kkr.voroparser = aiida_kkr.parsers.voro:VoronoiParser",
+        "kkr.kkrparser = aiida_kkr.parsers.kkr:KkrParser",
+        "kkr.kkrimporterparser = aiida_kkr.parsers.kkrimporter:KkrImporterParser",
+        "kkr.kkrimpparser = aiida_kkr.parsers.kkrimp:KkrimpParser"
+      ],
+      "aiida.data": [
+        "kkr.kkrstructure = aiida_kkr.data.kkrstructure:KkrstructureData"
+      ],
+      "aiida.workflows": [
+        "kkr.scf = aiida_kkr.workflows.kkr_scf:kkr_scf_wc",
+        "kkr.dos = aiida_kkr.workflows.dos:kkr_dos_wc",
+        "kkr.eos = aiida_kkr.workflows.eos:kkr_eos_wc",
+        "kkr.startpot = aiida_kkr.workflows.voro_start:kkr_startpot_wc",
+        "kkr.check_mag = aiida_kkr.workflows.check_magnetic_state:kkr_check_mag_wc",
+        "kkr.convergence_check = aiida_kkr.workflows.check_para_convergence:kkr_check_para_wc",
+        "kkr.gf_writeout = aiida_kkr.workflows.gf_writeout:kkr_flex_wc",
+        "kkr.imp_sub = aiida_kkr.workflows.kkr_imp_sub:kkr_imp_sub_wc",
+        "kkr.imp = aiida_kkr.workflows.kkr_imp:kkr_imp_wc"
+      ],
+      "console_scripts": [
+        "kkrstructure = aiida_kkr.cmdline.data_cli:cli"
+      ]
+    },
+    "metadata": {
+      "author": "Philipp Ruessmann, Jens Broeder, Fabian Bertoldo",
+      "author_email": "p.ruessmann@fz-juelich.de",
+      "version": "1.1.9-dev",
+      "description": "AiiDA plugin for the KKR code",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Development Status :: 4 - Beta",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Natural Language :: English",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0b6,<2.0.0"
+  },
+  "lammps": {
+    "name": "aiida-lammps",
+    "entry_point": "lammps",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-lammps",
+        "version": "0.4.1b3",
+        "description": "AiiDA plugin for LAMMPS",
+        "url": "https://github.com/abelcarreras/aiida-lammps",
+        "author": "Abel Carreras",
+        "author_email": "abelcarreras83@gmail.com",
+        "license": "MIT license",
+        "install_requires": [
+          "aiida-core==1.0.0b3",
+          "numpy",
+          "packaging",
+          "python-dateutil",
+          "jsonschema",
+          "six",
+          "ase>=3.12.0,<4.0.0"
+        ],
+        "reentry_register": true,
+        "include_package_data": true,
+        "entry_points": {
+          "aiida.calculations": [
+            "lammps.combinate = aiida_lammps.calculations.lammps.combinate:CombinateCalculation",
+            "lammps.force = aiida_lammps.calculations.lammps.force:ForceCalculation",
+            "lammps.md = aiida_lammps.calculations.lammps.md:MdCalculation",
+            "lammps.optimize = aiida_lammps.calculations.lammps.optimize:OptimizeCalculation",
+            "dynaphopy = aiida_lammps.calculations.dynaphopy: DynaphopyCalculation"
+          ],
+          "aiida.parsers": [
+            "lammps.force = aiida_lammps.parsers.lammps.force:ForceParser",
+            "lammps.md = aiida_lammps.parsers.lammps.md:MdParser",
+            "lammps.optimize = aiida_lammps.parsers.lammps.optimize:OptimizeParser",
+            "dynaphopy = aiida_lammps.parsers.dynaphopy: DynaphopyParser"
+          ],
+          "aiida.data": [
+            "lammps.potential = aiida_lammps.data.potential:EmpiricalPotential"
+          ],
+          "lammps.potentials": [
+            "eam =  aiida_lammps.data.potential.eam",
+            "lennard_jones =  aiida_lammps.data.potential.lennard_jones",
+            "reaxff =  aiida_lammps.data.potential.reaxff",
+            "tersoff =  aiida_lammps.data.potential.tersoff"
+          ]
+        },
+        "extras_require": {
+          "testing": [
+            "mock==2.0.0",
+            "pgtest==1.2.0",
+            "sqlalchemy-diff==0.1.3",
+            "pytest==3.6.3",
+            "pytest-cov",
+            "pytest-timeout",
+            "pytest-regressions",
+            "wheel>=0.31"
+          ],
+          "code_style": [
+            "flake8<3.8.0,>=3.7.0"
+          ],
+          "phonopy": [
+            "dynaphopy"
+          ]
+        }
+      }
+    ],
+    "pip_url": "git+https://github.com/abelcarreras/aiida-lammps",
+    "code_home": "https://github.com/abelcarreras/aiida-lammps",
+    "package_name": "aiida_lammps",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "lammps.combinate = aiida_lammps.calculations.lammps.combinate:CombinateCalculation",
+        "lammps.force = aiida_lammps.calculations.lammps.force:ForceCalculation",
+        "lammps.md = aiida_lammps.calculations.lammps.md:MdCalculation",
+        "lammps.optimize = aiida_lammps.calculations.lammps.optimize:OptimizeCalculation",
+        "dynaphopy = aiida_lammps.calculations.dynaphopy: DynaphopyCalculation"
+      ],
+      "aiida.parsers": [
+        "lammps.force = aiida_lammps.parsers.lammps.force:ForceParser",
+        "lammps.md = aiida_lammps.parsers.lammps.md:MdParser",
+        "lammps.optimize = aiida_lammps.parsers.lammps.optimize:OptimizeParser",
+        "dynaphopy = aiida_lammps.parsers.dynaphopy: DynaphopyParser"
+      ],
+      "aiida.data": [
+        "lammps.potential = aiida_lammps.data.potential:EmpiricalPotential"
+      ],
+      "lammps.potentials": [
+        "eam =  aiida_lammps.data.potential.eam",
+        "lennard_jones =  aiida_lammps.data.potential.lennard_jones",
+        "reaxff =  aiida_lammps.data.potential.reaxff",
+        "tersoff =  aiida_lammps.data.potential.tersoff"
+      ]
+    },
+    "metadata": {
+      "author": "Abel Carreras",
+      "author_email": "abelcarreras83@gmail.com",
+      "version": "0.4.1b3",
+      "description": "AiiDA plugin for LAMMPS",
+      "classifiers": []
+    },
+    "aiida_version": "==1.0.0b3"
+  },
+  "nwchem": {
+    "name": "aiida-nwchem",
+    "entry_point": "nwchem",
+    "state": "stable",
+    "pip_url": "aiida-nwchem",
+    "plugin_info": [
+      "setuptools",
+      {
+        "author": "The AiiDA team",
+        "author_email": "developers@aiida.net",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Development Status :: 4 - Beta"
+        ],
+        "description": "The official AiiDA plugin for NWChem",
+        "entry_points": {
+          "aiida.calculations": [
+            "nwchem.basic = aiida_nwchem.calculations.basic:BasicCalculation",
+            "nwchem.pymatgen = aiida_nwchem.calculations.nwcpymatgen:NwcpymatgenCalculation"
+          ],
+          "aiida.parsers": [
+            "nwchem.basic = aiida_nwchem.parsers.basic:BasicParser",
+            "nwchem.basenwc = aiida_nwchem.parsers.__init__:BasenwcParser",
+            "nwchem.pymatgen = aiida_nwchem.parsers.nwcpymatgen:NwcpymatgenParser"
+          ],
+          "aiida.tests": [
+            "nwchem.tcodexporter = aiida_nwchem.tests.tcodexporter"
+          ],
+          "aiida.tools.dbexporters.tcod_plugins": [
+            "nwchem.nwcpymatgen = aiida_nwchem.tools.dbexporters.tcod_plugins.nwcpymatgen:NwcpymatgenTcodtranslator"
+          ]
+        },
+        "extras_require": {
+          "dev_precommit": [
+            "pre-commit"
+          ],
+          "docs": [
+            "Sphinx",
+            "docutils",
+            "sphinx_rtd_theme"
+          ]
+        },
+        "install_requires": [
+          "aiida-core>=0.10.0rc1"
+        ],
+        "license": "MIT License",
+        "name": "aiida_nwchem",
+        "url": "https://github.com/aiidateam/aiida-nwchem",
+        "version": "1.0.2"
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-nwchem",
+    "documentation_url": "https://aiida-nwchem.readthedocs.io/",
+    "package_name": "aiida_nwchem",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "nwchem.basic = aiida_nwchem.calculations.basic:BasicCalculation",
+        "nwchem.pymatgen = aiida_nwchem.calculations.nwcpymatgen:NwcpymatgenCalculation"
+      ],
+      "aiida.parsers": [
+        "nwchem.basic = aiida_nwchem.parsers.basic:BasicParser",
+        "nwchem.basenwc = aiida_nwchem.parsers.__init__:BasenwcParser",
+        "nwchem.pymatgen = aiida_nwchem.parsers.nwcpymatgen:NwcpymatgenParser"
+      ],
+      "aiida.tests": [
+        "nwchem.tcodexporter = aiida_nwchem.tests.tcodexporter"
+      ],
+      "aiida.tools.dbexporters.tcod_plugins": [
+        "nwchem.nwcpymatgen = aiida_nwchem.tools.dbexporters.tcod_plugins.nwcpymatgen:NwcpymatgenTcodtranslator"
+      ]
+    },
+    "metadata": {
+      "author": "The AiiDA team",
+      "author_email": "developers@aiida.net",
+      "version": "1.0.2",
+      "description": "The official AiiDA plugin for NWChem",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Development Status :: 4 - Beta"
+      ]
+    },
+    "aiida_version": ">=0.10.0rc1"
+  },
+  "optimize": {
+    "name": "aiida-optimize",
+    "entry_point": "optimize",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-optimize",
+        "url": "https://aiida-optimize.readthedocs.io/",
+        "description": "AiiDA Plugin for running optimization algorithms.",
+        "author": "Dominik Gresch",
+        "author_email": "greschd@gmx.ch",
+        "license": "Apache 2.0",
+        "classifiers": [
+          "Development Status :: 3 - Alpha",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: Apache Software License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Topic :: Scientific/Engineering :: Physics"
+        ],
+        "keywords": [
+          "AiiDA",
+          "workflows",
+          "optimization"
+        ],
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0<2.0.0",
+          "fsc.export",
+          "aiida-tools>=0.2.0",
+          "future",
+          "numpy",
+          "scipy",
+          "decorator",
+          "pyyaml"
+        ],
+        "extras_require": {
+          ":python_version < \"3\"": [
+            "chainmap"
+          ],
+          "docs": [
+            "sphinx",
+            "sphinx-rtd-theme"
+          ],
+          "testing": [
+            "pytest>=3.6",
+            "pytest-cov",
+            "aiida-pytest"
+          ],
+          "dev_precommit": [
+            "yapf==0.28",
+            "pre-commit",
+            "prospector==1.1.7",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.3.1; python_version>='3.0'"
+          ]
+        },
+        "entry_points": {
+          "aiida.workflows": [
+            "optimize.optimize = aiida_optimize.workchain:OptimizationWorkChain"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/greschd/aiida-optimize",
+    "documentation_url": "https://aiida-optimize.readthedocs.io",
+    "pip_url": "aiida-optimize",
+    "package_name": "aiida_optimize",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.workflows": [
+        "optimize.optimize = aiida_optimize.workchain:OptimizationWorkChain"
+      ]
+    },
+    "metadata": {
+      "author": "Dominik Gresch",
+      "author_email": "greschd@gmx.ch",
+      "version": "",
+      "description": "AiiDA Plugin for running optimization algorithms.",
+      "classifiers": [
+        "Development Status :: 3 - Alpha",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Physics"
+      ]
+    },
+    "aiida_version": ">=1.0.0<2.0.0"
+  },
+  "phonopy": {
+    "name": "aiida-phonopy",
+    "entry_point": "phonopy",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-phonopy",
+        "version": "0.1",
+        "description": "AiiDA plugin for running phonon calculations using phonopy",
+        "author": "Atsushi Togo",
+        "author_email": "atz.togo@gmail.com",
+        "license": "MIT license",
+        "install_requires": [
+          "phonopy",
+          "numpy",
+          "seekpath"
+        ],
+        "setup_requires": [
+          "reentry"
+        ],
+        "entry_points": {
+          "aiida.calculations": [
+            "phonopy.phonopy = aiida_phonopy.calcs.phonopy: PhonopyCalculation"
+          ],
+          "aiida.parsers": [
+            "phonopy = aiida_phonopy.parsers.phonopy: PhonopyParser"
+          ],
+          "aiida.workflows": [
+            "phonopy.phonon = aiida_phonopy.workflows.phonopy: PhonopyWorkChain",
+            "phonopy.iter_ha = aiida_phonopy.workflows.iter_ha: IterHarmonicApproximation"
+          ]
+        },
+        "url": "https://github.com/aiida-phonopy/aiida-phonopy"
+      }
+    ],
+    "code_home": "https://github.com/abelcarreras/aiida-phonopy",
+    "pip_url": "git+https://github.com/abelcarreras/aiida-phonopy",
+    "documentation_url": "https://aiida-phonopy.readthedocs.io/",
+    "package_name": "aiida_phonopy",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "phonopy.phonopy = aiida_phonopy.calcs.phonopy: PhonopyCalculation"
+      ],
+      "aiida.parsers": [
+        "phonopy = aiida_phonopy.parsers.phonopy: PhonopyParser"
+      ],
+      "aiida.workflows": [
+        "phonopy.phonon = aiida_phonopy.workflows.phonopy: PhonopyWorkChain",
+        "phonopy.iter_ha = aiida_phonopy.workflows.iter_ha: IterHarmonicApproximation"
+      ]
+    },
+    "metadata": {
+      "author": "Atsushi Togo",
+      "author_email": "atz.togo@gmail.com",
+      "version": "0.1",
+      "description": "AiiDA plugin for running phonon calculations using phonopy",
+      "classifiers": []
+    },
+    "aiida_version": null
+  },
+  "phtools": {
+    "name": "aiida-phtools",
+    "entry_point": "phtools",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-phtools",
+        "author": "Leopold Talirz",
+        "author_email": "leopold.talirz@gmail.com",
+        "description": "AiiDA plugin for persistence homology tools, used to analyze nanoporous materials.",
+        "url": "https://github.com/ltalirz/aiida-phtools",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Framework :: AiiDA"
+        ],
+        "version": "0.1.0b1",
+        "entry_points": {
+          "aiida.calculations": [
+            "phtools.surface = aiida_phtools.calculations.pore_surface:PoreSurfaceCalculation",
+            "phtools.dmatrix = aiida_phtools.calculations.distance_matrix:DistanceMatrixCalculation"
+          ],
+          "aiida.parsers": [
+            "phtools.surface = aiida_phtools.parsers.pore_surface:PoreSurfaceParser",
+            "phtools.dmatrix = aiida_phtools.parsers.distance_matrix:DistanceMatrixParser"
+          ],
+          "aiida.data": [
+            "phtools.surface = aiida_phtools.data.pore_surface:PoreSurfaceParameters"
+          ]
+        },
+        "scripts": [
+          "examples/cli.py"
+        ],
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core >=0.12.3,<1.0",
+          "aiida-zeopp >=0.2,<1.0",
+          "aiida-gudhi",
+          "voluptuous"
+        ],
+        "extras_require": {
+          "testing": [
+            "aiida-core[testing]"
+          ],
+          "pre-commit": [
+            "pre-commit",
+            "yapf",
+            "prospector",
+            "pylint"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/ltalirz/aiida-phtools",
+    "pip_url": "aiida-phtools",
+    "package_name": "aiida_phtools",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "phtools.surface = aiida_phtools.calculations.pore_surface:PoreSurfaceCalculation",
+        "phtools.dmatrix = aiida_phtools.calculations.distance_matrix:DistanceMatrixCalculation"
+      ],
+      "aiida.parsers": [
+        "phtools.surface = aiida_phtools.parsers.pore_surface:PoreSurfaceParser",
+        "phtools.dmatrix = aiida_phtools.parsers.distance_matrix:DistanceMatrixParser"
+      ],
+      "aiida.data": [
+        "phtools.surface = aiida_phtools.data.pore_surface:PoreSurfaceParameters"
+      ]
+    },
+    "metadata": {
+      "author": "Leopold Talirz",
+      "author_email": "leopold.talirz@gmail.com",
+      "version": "0.1.0b1",
+      "description": "AiiDA plugin for persistence homology tools, used to analyze nanoporous materials.",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=0.12.3,<1.0"
+  },
+  "plumed": {
+    "name": "aiida-plumed",
+    "entry_point": "plumed",
+    "state": "development",
+    "code_home": "https://github.com/ConradJohnston/aiida-plumed",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-plumed",
+        "author": "Conrad Johnston",
+        "author_email": "conrad.s.johnston@googlemail.com",
+        "description": "AiiDA plugin providing support for Plumed2",
+        "url": "https://github.com/ConradJohnston/aiida-plumed",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: MIT License",
+          "Natural Language :: English",
+          "Framework :: AiiDA",
+          "Development Status :: 2 - Pre-Alpha"
+        ],
+        "version": "0.1.0a0",
+        "entry_points": {
+          "aiida.data": [
+            "plumed = aiida_plumed.data:DiffParameters"
+          ],
+          "aiida.calculations": [
+            "plumed = aiida_plumed.calculations:DiffCalculation"
+          ],
+          "aiida.parsers": [
+            "plumed = aiida_plumed.parsers:DiffParser"
+          ],
+          "aiida.cmdline.data": [
+            "plumed = aiida_plumed.cli:data_cli"
+          ]
+        },
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0b3,<2.0.0",
+          "six",
+          "voluptuous"
+        ],
+        "extras_require": {
+          "testing": [
+            "pgtest==1.2.0",
+            "wheel>=0.31",
+            "coverage",
+            "pytest>=3.6.3,<5.0.0",
+            "pytest-cov>=2.6.1,<5.0.0"
+          ],
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.27.0",
+            "prospector==0.12.11",
+            "pylint==1.9.4"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "pip_url": "aiida-plumed",
+    "documentation_url": "https://aiida-plumed.readthedocs.io/",
+    "package_name": "aiida_plumed",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.data": [
+        "plumed = aiida_plumed.data:DiffParameters"
+      ],
+      "aiida.calculations": [
+        "plumed = aiida_plumed.calculations:DiffCalculation"
+      ],
+      "aiida.parsers": [
+        "plumed = aiida_plumed.parsers:DiffParser"
+      ],
+      "aiida.cmdline.data": [
+        "plumed = aiida_plumed.cli:data_cli"
+      ]
+    },
+    "metadata": {
+      "author": "Conrad Johnston",
+      "author_email": "conrad.s.johnston@googlemail.com",
+      "version": "0.1.0a0",
+      "description": "AiiDA plugin providing support for Plumed2",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Framework :: AiiDA",
+        "Development Status :: 2 - Pre-Alpha"
+      ]
+    },
+    "aiida_version": ">=1.0.0b3,<2.0.0"
+  },
+  "porousmaterials": {
+    "name": "aiida-porousmaterials",
+    "entry_point": "porousmaterials",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-porousmaterials",
+        "author": "Pezhman Zarabadi-Poor",
+        "author_email": "pzarabadip@gmail.com",
+        "description": "AiiDA plugin for PorousMaterials code",
+        "url": "https://github.com/pzarabadip/aiida-porousmaterials",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: MIT License",
+          "Natural Language :: English",
+          "Framework :: AiiDA"
+        ],
+        "version": "1.0.0a1",
+        "setup_requires": [
+          "reentry"
+        ],
+        "install_requires": [
+          "aiida_core >= 1.0.0b5"
+        ],
+        "entry_points": {
+          "aiida.calculations": [
+            "porousmaterials = aiida_porousmaterials.calculations:PorousMaterialsCalculation"
+          ],
+          "aiida.parsers": [
+            "porousmaterials = aiida_porousmaterials.parser:PorousMaterialsParser"
+          ],
+          "aiida.workflows": [
+            "porousmaterials.base = aiida_porousmaterials.workchains:PorousMaterialsBaseWorkChain",
+            "aiida_porousmaterials.workflows.voronoi_energy=aiida_porousmaterials.workflows.voronoi_energy:VoronoiEnergyWorkChain"
+          ]
+        },
+        "reentry_register": true,
+        "data_files": [
+          [
+            ".",
+            [
+              "setup.json"
+            ]
+          ]
+        ],
+        "extras_require": {
+          "test": [
+            "pytest==4.4.1"
+          ],
+          "pre-commit": [
+            "pre-commit==1.16.1",
+            "yapf==0.27.0",
+            "prospector==1.1.6.2",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.2.2; python_version>='3.0'"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/pzarabadip/aiida-porousmaterials",
+    "pip_url": "git+https://github.com/pzarabadip/aiida-porousmaterials",
+    "package_name": "aiida_porousmaterials",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "porousmaterials = aiida_porousmaterials.calculations:PorousMaterialsCalculation"
+      ],
+      "aiida.parsers": [
+        "porousmaterials = aiida_porousmaterials.parser:PorousMaterialsParser"
+      ],
+      "aiida.workflows": [
+        "porousmaterials.base = aiida_porousmaterials.workchains:PorousMaterialsBaseWorkChain",
+        "aiida_porousmaterials.workflows.voronoi_energy=aiida_porousmaterials.workflows.voronoi_energy:VoronoiEnergyWorkChain"
+      ]
+    },
+    "metadata": {
+      "author": "Pezhman Zarabadi-Poor",
+      "author_email": "pzarabadip@gmail.com",
+      "version": "1.0.0a1",
+      "description": "AiiDA plugin for PorousMaterials code",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0b5"
+  },
+  "qeq": {
+    "name": "aiida-qeq",
+    "entry_point": "qeq",
+    "state": "stable",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-qeq",
+        "author": "Leopold Talirz, Daniele Ongari",
+        "author_email": "leopold.talirz@gmail.com",
+        "description": "AiiDA plugin for computing electronic charges on atoms using equilibration-type models (QEq, EQEq, ...).",
+        "url": "https://github.com/ltalirz/aiida-qeq",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Framework :: AiiDA"
+        ],
+        "version": "1.0.0a1",
+        "entry_points": {
+          "aiida.data": [
+            "qeq.eqeq = aiida_qeq.data.eqeq:EQeqParameters",
+            "qeq.qeq = aiida_qeq.data.qeq:QeqParameters"
+          ],
+          "aiida.calculations": [
+            "qeq.eqeq = aiida_qeq.calculations.eqeq:EQeqCalculation",
+            "qeq.qeq = aiida_qeq.calculations.qeq:QeqCalculation"
+          ],
+          "aiida.parsers": [
+            "qeq.eqeq = aiida_qeq.parsers.eqeq:EQeqParser",
+            "qeq.qeq = aiida_qeq.parsers.qeq:QeqParser"
+          ]
+        },
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0b1,<2.0.0",
+          "six",
+          "voluptuous"
+        ],
+        "extras_require": {
+          "testing": [
+            "pgtest==1.2.0",
+            "pytest>=4.4,<5.0.0",
+            "pytest-cov>=2.6.1,<3.0.0",
+            "coverage"
+          ],
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.26.0",
+            "prospector==0.12.11",
+            "pylint==1.9.3"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/ltalirz/aiida-qeq",
+    "pip_url": "aiida-qeq",
+    "package_name": "aiida_qeq",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.data": [
+        "qeq.eqeq = aiida_qeq.data.eqeq:EQeqParameters",
+        "qeq.qeq = aiida_qeq.data.qeq:QeqParameters"
+      ],
+      "aiida.calculations": [
+        "qeq.eqeq = aiida_qeq.calculations.eqeq:EQeqCalculation",
+        "qeq.qeq = aiida_qeq.calculations.qeq:QeqCalculation"
+      ],
+      "aiida.parsers": [
+        "qeq.eqeq = aiida_qeq.parsers.eqeq:EQeqParser",
+        "qeq.qeq = aiida_qeq.parsers.qeq:QeqParser"
+      ]
+    },
+    "metadata": {
+      "author": "Leopold Talirz, Daniele Ongari",
+      "author_email": "leopold.talirz@gmail.com",
+      "version": "1.0.0a1",
+      "description": "AiiDA plugin for computing electronic charges on atoms using equilibration-type models (QEq, EQEq, ...).",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0b1,<2.0.0"
+  },
+  "quantumespresso": {
+    "name": "aiida-quantumespresso",
+    "entry_point": "quantumespresso",
+    "state": "stable",
+    "pip_url": "aiida-quantumespresso",
+    "plugin_info": [
+      "setuptools",
+      {
+        "author": "The AiiDA team",
+        "author_email": "developers@aiida.net",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Development Status :: 4 - Beta"
+        ],
+        "description": "The official AiiDA plugin for Quantum ESPRESSO",
+        "entry_points": {
+          "aiida.calculations": [
+            "quantumespresso.cp = aiida_quantumespresso.calculations.cp:CpCalculation",
+            "quantumespresso.dos = aiida_quantumespresso.calculations.dos:DosCalculation",
+            "quantumespresso.matdyn = aiida_quantumespresso.calculations.matdyn:MatdynCalculation",
+            "quantumespresso.namelists = aiida_quantumespresso.calculations.namelists:NamelistsCalculation",
+            "quantumespresso.neb = aiida_quantumespresso.calculations.neb:NebCalculation",
+            "quantumespresso.ph = aiida_quantumespresso.calculations.ph:PhCalculation",
+            "quantumespresso.pp = aiida_quantumespresso.calculations.pp:PpCalculation",
+            "quantumespresso.pw = aiida_quantumespresso.calculations.pw:PwCalculation",
+            "quantumespresso.projwfc = aiida_quantumespresso.calculations.projwfc:ProjwfcCalculation",
+            "quantumespresso.pw2wannier90 = aiida_quantumespresso.calculations.pw2wannier90:Pw2wannier90Calculation",
+            "quantumespresso.q2r = aiida_quantumespresso.calculations.q2r:Q2rCalculation",
+            "quantumespresso.pwimmigrant = aiida_quantumespresso.calculations.pwimmigrant:PwimmigrantCalculation"
+          ],
+          "aiida.data": [
+            "quantumespresso.forceconstants = aiida_quantumespresso.data.forceconstants:ForceconstantsData"
+          ],
+          "aiida.parsers": [
+            "quantumespresso.basicpw = aiida_quantumespresso.parsers.basicpw:BasicpwParser",
+            "quantumespresso.cp = aiida_quantumespresso.parsers.cp:CpParser",
+            "quantumespresso.dos = aiida_quantumespresso.parsers.dos:DosParser",
+            "quantumespresso.matdyn = aiida_quantumespresso.parsers.matdyn:MatdynParser",
+            "quantumespresso.neb = aiida_quantumespresso.parsers.neb:NebParser",
+            "quantumespresso.ph = aiida_quantumespresso.parsers.ph:PhParser",
+            "quantumespresso.projwfc = aiida_quantumespresso.parsers.projwfc:ProjwfcParser",
+            "quantumespresso.pw = aiida_quantumespresso.parsers.pw:PwParser",
+            "quantumespresso.q2r = aiida_quantumespresso.parsers.q2r:Q2rParser",
+            "quantumespresso.pw2wannier90 = aiida_quantumespresso.parsers.pw2wannier90:Pw2wannier90Parser"
+          ],
+          "aiida.tests": [
+            "quantumespresso.parsers = tests.parsers.parsers",
+            "quantumespresso.pw = tests.parsers.quantumespressopw",
+            "quantumespresso.pw_input = tests.parsers.pwinputparser",
+            "quantumespresso.pw_immigrant = tests.parsers.quantumespressopwimmigrant",
+            "quantumespresso.tcodexporter = tests.parsers.tcodexporter"
+          ],
+          "aiida.tools.dbexporters.tcod_plugins": [
+            "quantumespresso.cp = aiida_quantumespresso.tools.dbexporters.tcod_plugins.cp:CpTcodtranslator",
+            "quantumespresso.pw = aiida_quantumespresso.tools.dbexporters.tcod_plugins.pw:PwTcodtranslator"
+          ],
+          "aiida.workflows": [
+            "quantumespresso.ph.base = aiida_quantumespresso.workflows.ph.base:PhBaseWorkChain",
+            "quantumespresso.pw.base = aiida_quantumespresso.workflows.pw.base:PwBaseWorkChain",
+            "quantumespresso.pw.relax = aiida_quantumespresso.workflows.pw.relax:PwRelaxWorkChain",
+            "quantumespresso.pw.bands = aiida_quantumespresso.workflows.pw.bands:PwBandsWorkChain",
+            "quantumespresso.pw.band_structure = aiida_quantumespresso.workflows.pw.band_structure:PwBandStructureWorkChain",
+            "quantumespresso.q2r.base = aiida_quantumespresso.workflows.q2r.base:Q2rBaseWorkChain",
+            "quantumespresso.matdyn.base = aiida_quantumespresso.workflows.matdyn.base:MatdynBaseWorkChain"
+          ],
+          "console_scripts": [
+            "launch_calculation_pw = aiida_quantumespresso.cli.calculations.pw.base:launch",
+            "launch_workflow_pw_band_structure = aiida_quantumespresso.cli.workflows.pw.band_structure:launch",
+            "launch_workflow_pw_bands = aiida_quantumespresso.cli.workflows.pw.bands:launch",
+            "launch_workflow_pw_relax = aiida_quantumespresso.cli.workflows.pw.relax:launch",
+            "launch_workflow_pw_base = aiida_quantumespresso.cli.workflows.pw.base:launch",
+            "launch_workflow_ph_base = aiida_quantumespresso.cli.workflows.ph.base:launch",
+            "launch_workflow_q2r_base = aiida_quantumespresso.cli.workflows.q2r.base:launch",
+            "launch_workflow_matdyn_base = aiida_quantumespresso.cli.workflows.matdyn.base:launch"
+          ]
+        },
+        "extras_require": {
+          "dev_precommit": [
+            "pre-commit"
+          ],
+          "docs": [
+            "Sphinx",
+            "docutils",
+            "sphinx_rtd_theme"
+          ]
+        },
+        "install_requires": [
+          "aiida_core[atomic_tools]>=0.12.0,<1.0.0",
+          "click"
+        ],
+        "license": "MIT License",
+        "name": "aiida_quantumespresso",
+        "url": "https://github.com/aiidateam/aiida-quantumespresso",
+        "version": "2.1.0"
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-quantumespresso",
+    "documentation_url": "https://aiida-quantumespresso.readthedocs.io/",
+    "package_name": "aiida_quantumespresso",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "quantumespresso.cp = aiida_quantumespresso.calculations.cp:CpCalculation",
+        "quantumespresso.dos = aiida_quantumespresso.calculations.dos:DosCalculation",
+        "quantumespresso.matdyn = aiida_quantumespresso.calculations.matdyn:MatdynCalculation",
+        "quantumespresso.namelists = aiida_quantumespresso.calculations.namelists:NamelistsCalculation",
+        "quantumespresso.neb = aiida_quantumespresso.calculations.neb:NebCalculation",
+        "quantumespresso.ph = aiida_quantumespresso.calculations.ph:PhCalculation",
+        "quantumespresso.pp = aiida_quantumespresso.calculations.pp:PpCalculation",
+        "quantumespresso.pw = aiida_quantumespresso.calculations.pw:PwCalculation",
+        "quantumespresso.projwfc = aiida_quantumespresso.calculations.projwfc:ProjwfcCalculation",
+        "quantumespresso.pw2wannier90 = aiida_quantumespresso.calculations.pw2wannier90:Pw2wannier90Calculation",
+        "quantumespresso.q2r = aiida_quantumespresso.calculations.q2r:Q2rCalculation",
+        "quantumespresso.pwimmigrant = aiida_quantumespresso.calculations.pwimmigrant:PwimmigrantCalculation"
+      ],
+      "aiida.data": [
+        "quantumespresso.forceconstants = aiida_quantumespresso.data.forceconstants:ForceconstantsData"
+      ],
+      "aiida.parsers": [
+        "quantumespresso.basicpw = aiida_quantumespresso.parsers.basicpw:BasicpwParser",
+        "quantumespresso.cp = aiida_quantumespresso.parsers.cp:CpParser",
+        "quantumespresso.dos = aiida_quantumespresso.parsers.dos:DosParser",
+        "quantumespresso.matdyn = aiida_quantumespresso.parsers.matdyn:MatdynParser",
+        "quantumespresso.neb = aiida_quantumespresso.parsers.neb:NebParser",
+        "quantumespresso.ph = aiida_quantumespresso.parsers.ph:PhParser",
+        "quantumespresso.projwfc = aiida_quantumespresso.parsers.projwfc:ProjwfcParser",
+        "quantumespresso.pw = aiida_quantumespresso.parsers.pw:PwParser",
+        "quantumespresso.q2r = aiida_quantumespresso.parsers.q2r:Q2rParser",
+        "quantumespresso.pw2wannier90 = aiida_quantumespresso.parsers.pw2wannier90:Pw2wannier90Parser"
+      ],
+      "aiida.tests": [
+        "quantumespresso.parsers = tests.parsers.parsers",
+        "quantumespresso.pw = tests.parsers.quantumespressopw",
+        "quantumespresso.pw_input = tests.parsers.pwinputparser",
+        "quantumespresso.pw_immigrant = tests.parsers.quantumespressopwimmigrant",
+        "quantumespresso.tcodexporter = tests.parsers.tcodexporter"
+      ],
+      "aiida.tools.dbexporters.tcod_plugins": [
+        "quantumespresso.cp = aiida_quantumespresso.tools.dbexporters.tcod_plugins.cp:CpTcodtranslator",
+        "quantumespresso.pw = aiida_quantumespresso.tools.dbexporters.tcod_plugins.pw:PwTcodtranslator"
+      ],
+      "aiida.workflows": [
+        "quantumespresso.ph.base = aiida_quantumespresso.workflows.ph.base:PhBaseWorkChain",
+        "quantumespresso.pw.base = aiida_quantumespresso.workflows.pw.base:PwBaseWorkChain",
+        "quantumespresso.pw.relax = aiida_quantumespresso.workflows.pw.relax:PwRelaxWorkChain",
+        "quantumespresso.pw.bands = aiida_quantumespresso.workflows.pw.bands:PwBandsWorkChain",
+        "quantumespresso.pw.band_structure = aiida_quantumespresso.workflows.pw.band_structure:PwBandStructureWorkChain",
+        "quantumespresso.q2r.base = aiida_quantumespresso.workflows.q2r.base:Q2rBaseWorkChain",
+        "quantumespresso.matdyn.base = aiida_quantumespresso.workflows.matdyn.base:MatdynBaseWorkChain"
+      ],
+      "console_scripts": [
+        "launch_calculation_pw = aiida_quantumespresso.cli.calculations.pw.base:launch",
+        "launch_workflow_pw_band_structure = aiida_quantumespresso.cli.workflows.pw.band_structure:launch",
+        "launch_workflow_pw_bands = aiida_quantumespresso.cli.workflows.pw.bands:launch",
+        "launch_workflow_pw_relax = aiida_quantumespresso.cli.workflows.pw.relax:launch",
+        "launch_workflow_pw_base = aiida_quantumespresso.cli.workflows.pw.base:launch",
+        "launch_workflow_ph_base = aiida_quantumespresso.cli.workflows.ph.base:launch",
+        "launch_workflow_q2r_base = aiida_quantumespresso.cli.workflows.q2r.base:launch",
+        "launch_workflow_matdyn_base = aiida_quantumespresso.cli.workflows.matdyn.base:launch"
+      ]
+    },
+    "metadata": {
+      "author": "The AiiDA team",
+      "author_email": "developers@aiida.net",
+      "version": "2.1.0",
+      "description": "The official AiiDA plugin for Quantum ESPRESSO",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Development Status :: 4 - Beta"
+      ]
+    },
+    "aiida_version": ">=0.12.0,<1.0.0"
+  },
+  "quantumespresso-hp": {
+    "name": "aiida-quantumespresso-hp",
+    "entry_point": "quantumespresso.hp",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "version": "0.1.0",
+        "name": "aiida_quantumespresso_hp",
+        "url": "https://github.com/sphuber/aiida-quantumespresso-hp",
+        "license": "MIT License",
+        "author": "Sebastiaan P. Huber",
+        "author_email": "mail@sphuber.net",
+        "description": "The AiiDA plugin for the Hubbard module of Quantum ESPRESSO",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Development Status :: 4 - Beta"
+        ],
+        "install_requires": [
+          "aiida-core>=1.0.0b6,<2.0",
+          "aiida-quantumespresso>=3.0.0a5,<4.0"
+        ],
+        "entry_points": {
+          "aiida.calculations": [
+            "quantumespresso.hp = aiida_quantumespresso_hp.calculations.hp:HpCalculation"
+          ],
+          "aiida.parsers": [
+            "quantumespresso.hp = aiida_quantumespresso_hp.parsers.hp:HpParser"
+          ],
+          "aiida.workflows": [
+            "quantumespresso.hp.main = aiida_quantumespresso_hp.workflows.hp.main:HpWorkChain",
+            "quantumespresso.hp.parallelize_atoms = aiida_quantumespresso_hp.workflows.hp.parallelize_atoms:HpParallelizeAtomsWorkChain",
+            "quantumespresso.hp.base = aiida_quantumespresso_hp.workflows.hp.base:HpBaseWorkChain",
+            "quantumespresso.hp.hubbard = aiida_quantumespresso_hp.workflows.hubbard:SelfConsistentHubbardWorkChain"
+          ],
+          "console_scripts": [
+            "launch_calculation_hp = aiida_quantumespresso_hp.cli.calculations.hp:launch",
+            "launch_workflow_hp_base = aiida_quantumespresso_hp.cli.workflows.hp.base:launch",
+            "launch_workflow_hp_main = aiida_quantumespresso_hp.cli.workflows.hp.main:launch",
+            "launch_workflow_hp_hubbard = aiida_quantumespresso_hp.cli.workflows.hubbard:launch"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/sphuber/aiida-quantumespresso-hp",
+    "pip_url": "git+https://github.com/sphuber/aiida-quantumespresso-hp",
+    "package_name": "aiida_quantumespresso_hp",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "quantumespresso.hp = aiida_quantumespresso_hp.calculations.hp:HpCalculation"
+      ],
+      "aiida.parsers": [
+        "quantumespresso.hp = aiida_quantumespresso_hp.parsers.hp:HpParser"
+      ],
+      "aiida.workflows": [
+        "quantumespresso.hp.main = aiida_quantumespresso_hp.workflows.hp.main:HpWorkChain",
+        "quantumespresso.hp.parallelize_atoms = aiida_quantumespresso_hp.workflows.hp.parallelize_atoms:HpParallelizeAtomsWorkChain",
+        "quantumespresso.hp.base = aiida_quantumespresso_hp.workflows.hp.base:HpBaseWorkChain",
+        "quantumespresso.hp.hubbard = aiida_quantumespresso_hp.workflows.hubbard:SelfConsistentHubbardWorkChain"
+      ],
+      "console_scripts": [
+        "launch_calculation_hp = aiida_quantumespresso_hp.cli.calculations.hp:launch",
+        "launch_workflow_hp_base = aiida_quantumespresso_hp.cli.workflows.hp.base:launch",
+        "launch_workflow_hp_main = aiida_quantumespresso_hp.cli.workflows.hp.main:launch",
+        "launch_workflow_hp_hubbard = aiida_quantumespresso_hp.cli.workflows.hubbard:launch"
+      ]
+    },
+    "metadata": {
+      "author": "Sebastiaan P. Huber",
+      "author_email": "mail@sphuber.net",
+      "version": "0.1.0",
+      "description": "The AiiDA plugin for the Hubbard module of Quantum ESPRESSO",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Development Status :: 4 - Beta"
+      ]
+    },
+    "aiida_version": ">=1.0.0b6,<2.0"
+  },
+  "raspa": {
+    "name": "aiida-raspa",
+    "entry_point": "raspa",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-raspa",
+        "author": "Aliaksandr Yakutovich",
+        "author_email": "aliaksandr.yakutovich@epfl.ch",
+        "description": "AiiDA plugin for RASPA code",
+        "url": "https://github.com/yakutovicha/aiida-raspa",
+        "license": "MIT License",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Development Status :: 4 - Beta"
+        ],
+        "version": "1.0.0a1",
+        "setup_requires": [
+          "reentry"
+        ],
+        "install_requires": [
+          "aiida_core >= 1.0.0b5"
+        ],
+        "entry_points": {
+          "aiida.calculations": [
+            "raspa = aiida_raspa.calculations:RaspaCalculation"
+          ],
+          "aiida.parsers": [
+            "raspa = aiida_raspa.parsers:RaspaParser"
+          ],
+          "aiida.workflows": [
+            "raspa.converge = aiida_raspa.workflows:RaspaConvergeWorkChain"
+          ]
+        },
+        "reentry_register": true,
+        "data_files": [
+          [
+            ".",
+            [
+              "setup.json"
+            ]
+          ]
+        ],
+        "extras_require": {
+          "test": [
+            "pytest==4.4.1"
+          ],
+          "pre-commit": [
+            "pre-commit==1.16.1",
+            "yapf==0.27.0",
+            "prospector==1.1.6.2",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.2.2; python_version>='3.0'"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/yakutovicha/aiida-raspa",
+    "pip_url": "aiida-raspa",
+    "package_name": "aiida_raspa",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "raspa = aiida_raspa.calculations:RaspaCalculation"
+      ],
+      "aiida.parsers": [
+        "raspa = aiida_raspa.parsers:RaspaParser"
+      ],
+      "aiida.workflows": [
+        "raspa.converge = aiida_raspa.workflows:RaspaConvergeWorkChain"
+      ]
+    },
+    "metadata": {
+      "author": "Aliaksandr Yakutovich",
+      "author_email": "aliaksandr.yakutovich@epfl.ch",
+      "version": "1.0.0a1",
+      "description": "AiiDA plugin for RASPA code",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Development Status :: 4 - Beta"
+      ]
+    },
+    "aiida_version": ">=1.0.0b5"
+  },
+  "siesta": {
+    "name": "aiida-siesta",
+    "entry_point": "siesta",
+    "state": "development",
+    "pip_url": "aiida-siesta",
+    "plugin_info": [
+      "setuptools",
+      {
+        "version": "1.0.0",
+        "name": "aiida-siesta",
+        "url": "https://github.com/albgar/aiida_siesta_plugin",
+        "keywords": [
+          "aiida",
+          "siesta",
+          "dft"
+        ],
+        "license": "MIT License",
+        "author": "Alberto Garcia, Victor M. Garcia-Suarez, Emanuele Bosoni, Vladimir Dikan",
+        "author_email": "albertog@icmab.es",
+        "description": "A plugin for Siesta's basic functionality within the AiiDA framework.",
+        "classifiers": [
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Development Status :: 3 - Alpha"
+        ],
+        "install_requires": [
+          "aiida_core[docs,atomic_tools]>=1.0.0b1,<2.0.0",
+          "pytest>=3.3.2"
+        ],
+        "extras_require": {
+          "dev": [
+            "pre-commit",
+            "prospector==1.1.5",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.2.2; python_version>='3.0'",
+            "astroid==2.1.0; python_version>='3.0'",
+            "pgtest==1.2.0",
+            "pytest==3.6.3",
+            "pytest-regressions==1.0.5",
+            "yapf==0.26.0"
+          ],
+          "docs": [
+            "Sphinx",
+            "docutils",
+            "sphinx_rtd_theme"
+          ]
+        },
+        "entry_points": {
+          "aiida.calculations": [
+            "siesta.siesta = aiida_siesta.calculations.siesta:SiestaCalculation",
+            "siesta.stm = aiida_siesta.calculations.stm:STMCalculation"
+          ],
+          "aiida.parsers": [
+            "siesta.parser = aiida_siesta.parsers.siesta:SiestaParser",
+            "siesta.stm = aiida_siesta.parsers.stm:STMParser"
+          ],
+          "aiida.workflows": [
+            "siesta.base = aiida_siesta.workflows.base:SiestaBaseWorkChain",
+            "siesta.bands = aiida_siesta.workflows.bands:SiestaBandsWorkChain",
+            "siesta.stm = aiida_siesta.workflows.stm:SiestaSTMWorkChain"
+          ],
+          "aiida.data": [
+            "siesta.psf = aiida_siesta.data.psf:PsfData",
+            "siesta.psml = aiida_siesta.data.psml:PsmlData"
+          ],
+          "aiida.cmdline.data": [
+            "psf = aiida_siesta.commands.data_psf:psfdata",
+            "psml = aiida_siesta.commands.data_psml:psmldata"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/albgar/aiida_siesta_plugin/tree/master",
+    "documentation_url": "https://aiida-siesta-plugin.readthedocs.io/",
+    "package_name": "aiida_siesta",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "siesta.siesta = aiida_siesta.calculations.siesta:SiestaCalculation",
+        "siesta.stm = aiida_siesta.calculations.stm:STMCalculation"
+      ],
+      "aiida.parsers": [
+        "siesta.parser = aiida_siesta.parsers.siesta:SiestaParser",
+        "siesta.stm = aiida_siesta.parsers.stm:STMParser"
+      ],
+      "aiida.workflows": [
+        "siesta.base = aiida_siesta.workflows.base:SiestaBaseWorkChain",
+        "siesta.bands = aiida_siesta.workflows.bands:SiestaBandsWorkChain",
+        "siesta.stm = aiida_siesta.workflows.stm:SiestaSTMWorkChain"
+      ],
+      "aiida.data": [
+        "siesta.psf = aiida_siesta.data.psf:PsfData",
+        "siesta.psml = aiida_siesta.data.psml:PsmlData"
+      ],
+      "aiida.cmdline.data": [
+        "psf = aiida_siesta.commands.data_psf:psfdata",
+        "psml = aiida_siesta.commands.data_psml:psmldata"
+      ]
+    },
+    "metadata": {
+      "author": "Alberto Garcia, Victor M. Garcia-Suarez, Emanuele Bosoni, Vladimir Dikan",
+      "author_email": "albertog@icmab.es",
+      "version": "1.0.0",
+      "description": "A plugin for Siesta's basic functionality within the AiiDA framework.",
+      "classifiers": [
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Development Status :: 3 - Alpha"
+      ]
+    },
+    "aiida_version": ">=1.0.0b1,<2.0.0"
+  },
+  "spex": {
+    "name": "aiida-spex",
+    "entry_point": "spex",
+    "state": "registered",
+    "code_home": "https://github.com/JuDFTteam/aiida-spex",
+    "plugin_info": null,
+    "pip_url": "git+https://github.com/JuDFTteam/aiida-spex",
+    "package_name": "aiida_spex",
+    "hosted_on": "github.com",
+    "entry_points": {},
+    "metadata": null,
+    "aiida_version": null
+  },
+  "strain": {
+    "name": "aiida-strain",
+    "entry_point": "strain",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-strain",
+        "description": "AiiDA Plugin for applying strain to structures",
+        "author": "Dominik Gresch",
+        "author_email": "greschd@gmx.ch",
+        "url": "https://aiida-strain.readthedocs.io",
+        "license": "Apache 2.0",
+        "classifiers": [
+          "Development Status :: 3 - Alpha",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: Apache Software License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Topic :: Scientific/Engineering :: Physics"
+        ],
+        "keywords": [
+          "strain",
+          "aiida",
+          "workflows"
+        ],
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core",
+          "strain",
+          "aiida-symmetry-representation",
+          "aiida-tools"
+        ],
+        "extras_require": {
+          "test": [
+            "aiida-pytest",
+            "pytest"
+          ],
+          "pre-commit": [
+            "pre-commit",
+            "yapf==0.25"
+          ]
+        },
+        "entry_points": {
+          "aiida.workflows": [
+            "strain.apply_strains = aiida_strain.work:ApplyStrains",
+            "strain.apply_strains_with_symmetry = aiida_strain.work:ApplyStrainsWithSymmetry"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/greschd/aiida-strain",
+    "documentation_url": "https://aiida-strain.readthedocs.io",
+    "pip_url": "aiida-strain",
+    "package_name": "aiida_strain",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.workflows": [
+        "strain.apply_strains = aiida_strain.work:ApplyStrains",
+        "strain.apply_strains_with_symmetry = aiida_strain.work:ApplyStrainsWithSymmetry"
+      ]
+    },
+    "metadata": {
+      "author": "Dominik Gresch",
+      "author_email": "greschd@gmx.ch",
+      "version": "",
+      "description": "AiiDA Plugin for applying strain to structures",
+      "classifiers": [
+        "Development Status :: 3 - Alpha",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Physics"
+      ]
+    },
+    "aiida_version": null
+  },
+  "symmetry-representation": {
+    "name": "aiida-symmetry-representation",
+    "entry_point": "symmetry_representation",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-symmetry-representation",
+        "description": "AiiDA Plugin for symmetry representations.",
+        "author": "Dominik Gresch",
+        "author_email": "greschd@gmx.ch",
+        "url": "https://aiida-symmetry-representation.readthedocs.io",
+        "license": "Apache 2.0",
+        "classifiers": [
+          "Development Status :: 3 - Alpha",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: Apache Software License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Topic :: Scientific/Engineering :: Physics"
+        ],
+        "keywords": "symmetry representation aiida workflow",
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core",
+          "aiida-tools",
+          "pymatgen<2019;python_version<\"3\"",
+          "pymatgen;python_version>=\"3\"",
+          "fsc.export"
+        ],
+        "extras_require": {
+          "test": [
+            "aiida-pytest",
+            "pytest"
+          ],
+          "pre-commit": [
+            "yapf==0.25",
+            "pre-commit"
+          ]
+        },
+        "entry_points": {
+          "aiida.calculations": [
+            "symmetry_representation.filter_symmetries = aiida_symmetry_representation.calculations.filter_symmetries:FilterSymmetriesCalculation"
+          ],
+          "aiida.parsers": [
+            "symmetry_representation.symmetry = aiida_symmetry_representation.parsers.symmetries:SymmetriesParser"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/greschd/aiida_symmetry_representation",
+    "documentation_url": "https://aiida-symmetry-representation.readthedocs.io",
+    "pip_url": "aiida-symmetry-representation",
+    "package_name": "aiida_symmetry_representation",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "symmetry_representation.filter_symmetries = aiida_symmetry_representation.calculations.filter_symmetries:FilterSymmetriesCalculation"
+      ],
+      "aiida.parsers": [
+        "symmetry_representation.symmetry = aiida_symmetry_representation.parsers.symmetries:SymmetriesParser"
+      ]
+    },
+    "metadata": {
+      "author": "Dominik Gresch",
+      "author_email": "greschd@gmx.ch",
+      "version": "",
+      "description": "AiiDA Plugin for symmetry representations.",
+      "classifiers": [
+        "Development Status :: 3 - Alpha",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Physics"
+      ]
+    },
+    "aiida_version": null
+  },
+  "tbextraction": {
+    "name": "aiida-tbextraction",
+    "entry_point": "tbextraction",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-tbextraction",
+        "description": "AiiDA Plugin for extracting tight-binding models",
+        "author": "Dominik Gresch",
+        "author_email": "greschd@gmx.ch",
+        "url": "https://aiida-tbextraction.readthedocs.io",
+        "license": "Apache 2.0",
+        "classifiers": [
+          "Development Status :: 3 - Alpha",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: Apache Software License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Topic :: Scientific/Engineering :: Physics"
+        ],
+        "keywords": "tight-binding extraction aiida workflows",
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core",
+          "aiida-wannier90",
+          "aiida-bands-inspect",
+          "aiida-tbmodels",
+          "aiida-optimize",
+          "fsc.export",
+          "aiida-tools",
+          "future"
+        ],
+        "extras_require": {
+          ":python_version < \"3\"": [
+            "chainmap",
+            "singledispatch"
+          ],
+          "dev": [
+            "pymatgen; python_version>=\"3\"",
+            "pymatgen<2019; python_version<\"3\"",
+            "aiida-pytest",
+            "ase",
+            "yapf==0.25",
+            "pre-commit",
+            "prospector==0.12.11",
+            "sphinx-rtd-theme",
+            "pylint==1.9.3"
+          ],
+          "strain": [
+            "aiida-strain"
+          ],
+          "vasp": [
+            "aiida-vasp"
+          ]
+        },
+        "entry_points": {
+          "aiida.workflows": [
+            "tbextraction.fp_run.base = aiida_tbextraction.fp_run:FirstPrinciplesRunBase",
+            "tbextraction.fp_run.split = aiida_tbextraction.fp_run:SplitFirstPrinciplesRun",
+            "tbextraction.fp_run.vasp = aiida_tbextraction.fp_run:VaspFirstPrinciplesRun",
+            "tbextraction.fp_run.reference_bands.base = aiida_tbextraction.fp_run.reference_bands:ReferenceBandsBase",
+            "tbextraction.fp_run.reference_bands.vasp = aiida_tbextraction.fp_run.reference_bands:VaspReferenceBands",
+            "tbextraction.fp_run.wannier_input.base = aiida_tbextraction.fp_run.wannier_input:WannierInputBase",
+            "tbextraction.fp_run.wannier_input.vasp = aiida_tbextraction.fp_run.wannier_input:VaspWannierInput",
+            "tbextraction.calculate_tb = aiida_tbextraction.calculate_tb:TightBindingCalculation",
+            "tbextraction.model_evaluation.base = aiida_tbextraction.model_evaluation:ModelEvaluationBase",
+            "tbextraction.model_evaluation.band_difference = aiida_tbextraction.model_evaluation:BandDifferenceModelEvaluation",
+            "tbextraction.energy_windows.run_window = aiida_tbextraction.energy_windows.run_window:RunWindow",
+            "tbextraction.energy_windows.window_search = aiida_tbextraction.energy_windows.window_search:WindowSearch",
+            "tbextraction.optimize_fp_tb = aiida_tbextraction.optimize_fp_tb:OptimizeFirstPrinciplesTightBinding",
+            "tbextraction.optimize_strained_fp_tb = aiida_tbextraction.optimize_strained_fp_tb:OptimizeStrainedFirstPrinciplesTightBinding"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/greschd/aiida-tbextraction",
+    "documentation_url": "https://aiida-tbextraction.readthedocs.io/",
+    "pip_url": "aiida-tbextraction",
+    "package_name": "aiida_tbextraction",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.workflows": [
+        "tbextraction.fp_run.base = aiida_tbextraction.fp_run:FirstPrinciplesRunBase",
+        "tbextraction.fp_run.split = aiida_tbextraction.fp_run:SplitFirstPrinciplesRun",
+        "tbextraction.fp_run.vasp = aiida_tbextraction.fp_run:VaspFirstPrinciplesRun",
+        "tbextraction.fp_run.reference_bands.base = aiida_tbextraction.fp_run.reference_bands:ReferenceBandsBase",
+        "tbextraction.fp_run.reference_bands.vasp = aiida_tbextraction.fp_run.reference_bands:VaspReferenceBands",
+        "tbextraction.fp_run.wannier_input.base = aiida_tbextraction.fp_run.wannier_input:WannierInputBase",
+        "tbextraction.fp_run.wannier_input.vasp = aiida_tbextraction.fp_run.wannier_input:VaspWannierInput",
+        "tbextraction.calculate_tb = aiida_tbextraction.calculate_tb:TightBindingCalculation",
+        "tbextraction.model_evaluation.base = aiida_tbextraction.model_evaluation:ModelEvaluationBase",
+        "tbextraction.model_evaluation.band_difference = aiida_tbextraction.model_evaluation:BandDifferenceModelEvaluation",
+        "tbextraction.energy_windows.run_window = aiida_tbextraction.energy_windows.run_window:RunWindow",
+        "tbextraction.energy_windows.window_search = aiida_tbextraction.energy_windows.window_search:WindowSearch",
+        "tbextraction.optimize_fp_tb = aiida_tbextraction.optimize_fp_tb:OptimizeFirstPrinciplesTightBinding",
+        "tbextraction.optimize_strained_fp_tb = aiida_tbextraction.optimize_strained_fp_tb:OptimizeStrainedFirstPrinciplesTightBinding"
+      ]
+    },
+    "metadata": {
+      "author": "Dominik Gresch",
+      "author_email": "greschd@gmx.ch",
+      "version": "",
+      "description": "AiiDA Plugin for extracting tight-binding models",
+      "classifiers": [
+        "Development Status :: 3 - Alpha",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Physics"
+      ]
+    },
+    "aiida_version": null
+  },
+  "tbmodels": {
+    "name": "aiida-tbmodels",
+    "entry_point": "tbmodels",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-tbmodels",
+        "version": "0.2.0",
+        "description": "AiiDA Plugin for running TBmodels",
+        "author": "Dominik Gresch",
+        "author_email": "greschd@gmx.ch",
+        "license": "Apache 2.0",
+        "url": "https://aiida-tbmodels.readthedocs.io",
+        "classifiers": [
+          "Development Status :: 3 - Alpha",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: Apache Software License",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: 3.7",
+          "Topic :: Scientific/Engineering :: Physics",
+          "Framework :: AiiDA"
+        ],
+        "keywords": [
+          "tbmodels",
+          "aiida",
+          "workflows"
+        ],
+        "entry_points": {
+          "aiida.calculations": [
+            "tbmodels.eigenvals = aiida_tbmodels.calculations.eigenvals:EigenvalsCalculation",
+            "tbmodels.parse = aiida_tbmodels.calculations.parse:ParseCalculation",
+            "tbmodels.slice = aiida_tbmodels.calculations.slice:SliceCalculation",
+            "tbmodels.symmetrize = aiida_tbmodels.calculations.symmetrize:SymmetrizeCalculation"
+          ],
+          "aiida.parsers": [
+            "tbmodels.model = aiida_tbmodels.parsers.model:ModelParser"
+          ]
+        },
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "six",
+          "future",
+          "aiida-core>=1.0.0<2.0.0",
+          "aiida-bands-inspect>=0.2.0b1"
+        ],
+        "extras_require": {
+          "testing": [
+            "pytest",
+            "aiida-pytest>=0.1.0a4"
+          ],
+          "docs": [
+            "sphinx",
+            "sphinx-rtd-theme"
+          ],
+          "dev_precommit": [
+            "yapf==0.28",
+            "pre-commit",
+            "prospector==1.1.7"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/greschd/aiida-tbmodels",
+    "documentation_url": "https://aiida-tbmodels.readthedocs.io",
+    "pip_url": "aiida-tbmodels",
+    "package_name": "aiida_tbmodels",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "tbmodels.eigenvals = aiida_tbmodels.calculations.eigenvals:EigenvalsCalculation",
+        "tbmodels.parse = aiida_tbmodels.calculations.parse:ParseCalculation",
+        "tbmodels.slice = aiida_tbmodels.calculations.slice:SliceCalculation",
+        "tbmodels.symmetrize = aiida_tbmodels.calculations.symmetrize:SymmetrizeCalculation"
+      ],
+      "aiida.parsers": [
+        "tbmodels.model = aiida_tbmodels.parsers.model:ModelParser"
+      ]
+    },
+    "metadata": {
+      "author": "Dominik Gresch",
+      "author_email": "greschd@gmx.ch",
+      "version": "0.2.0",
+      "description": "AiiDA Plugin for running TBmodels",
+      "classifiers": [
+        "Development Status :: 3 - Alpha",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0<2.0.0"
+  },
+  "tcod": {
+    "name": "aiida-tcod",
+    "entry_point": "tcod",
+    "state": "development",
+    "pip_url": "git+https://github.com/aiidateam/aiida-tcod",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-tcod",
+        "author": "The AiiDA team",
+        "author_email": "developers@aiida.net",
+        "description": "AiiDA plugin to interact with the TCOD",
+        "url": "https://github.com/aiidateam/aiida-tcod",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python"
+        ],
+        "version": "0.1.0a0",
+        "entry_points": {
+          "aiida.tools.dbexporters": [
+            "tcod = aiida.tools.dbexporters.tcod"
+          ]
+        },
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0b1",
+          "six"
+        ],
+        "extras_require": {
+          "testing": [
+            "mock==2.0.0",
+            "pgtest==1.1.0",
+            "sqlalchemy-diff==0.1.3",
+            "wheel>=0.31",
+            "coverage",
+            "pytest==3.6.3",
+            "pytest-cov==2.6.0"
+          ],
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.24.0",
+            "prospector==0.12.11",
+            "pylint==1.9.3"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-tcod",
+    "documentation_url": "https://aiida-tcod.readthedocs.io/",
+    "package_name": "aiida_tcod",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.tools.dbexporters": [
+        "tcod = aiida.tools.dbexporters.tcod"
+      ]
+    },
+    "metadata": {
+      "author": "The AiiDA team",
+      "author_email": "developers@aiida.net",
+      "version": "0.1.0a0",
+      "description": "AiiDA plugin to interact with the TCOD",
+      "classifiers": [
+        "Programming Language :: Python"
+      ]
+    },
+    "aiida_version": ">=1.0.0b1"
+  },
+  "uppasd": {
+    "name": "aiida-uppasd",
+    "entry_point": "uppasd",
+    "state": "registered",
+    "pip_url": "git+https://github.com/unkcpz/aiida-uppasd",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-uppasd",
+        "author": "The UppASD team",
+        "author_email": "uppasd@physics.uu.se",
+        "description": "AiiDA plugin for the atomistic spin dynamics code UppASD",
+        "url": "https://github.com/uppasd/aiida-uppasd",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: MIT License",
+          "Natural Language :: English",
+          "Framework :: AiiDA"
+        ],
+        "version": "0.1.0a0",
+        "entry_points": {
+          "aiida.data": [
+            "uppasd = aiida_uppasd.data:DiffParameters"
+          ],
+          "aiida.calculations": [
+            "uppasd = aiida_uppasd.calculations:DiffCalculation"
+          ],
+          "aiida.parsers": [
+            "uppasd = aiida_uppasd.parsers:DiffParser"
+          ],
+          "aiida.cmdline.data": [
+            "uppasd = aiida_uppasd.cli:data_cli"
+          ]
+        },
+        "include_package_data": true,
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core>=1.0.0b3,<2.0.0",
+          "six",
+          "voluptuous",
+          "pandas==0.24.2"
+        ],
+        "extras_require": {
+          "testing": [
+            "pgtest==1.2.0",
+            "wheel>=0.31",
+            "coverage",
+            "pytest>=3.6.3,<5.0.0",
+            "pytest-cov>=2.6.1,<5.0.0"
+          ],
+          "pre-commit": [
+            "pre-commit==1.11.0",
+            "yapf==0.27.0",
+            "prospector==0.12.11",
+            "pylint==1.9.4"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/uppasd/aiida-uppasd",
+    "documentation_url": "https://github.com/uppasd/aiida-uppasd/blob/master/README.md",
+    "package_name": "aiida_uppasd",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.data": [
+        "uppasd = aiida_uppasd.data:DiffParameters"
+      ],
+      "aiida.calculations": [
+        "uppasd = aiida_uppasd.calculations:DiffCalculation"
+      ],
+      "aiida.parsers": [
+        "uppasd = aiida_uppasd.parsers:DiffParser"
+      ],
+      "aiida.cmdline.data": [
+        "uppasd = aiida_uppasd.cli:data_cli"
+      ]
+    },
+    "metadata": {
+      "author": "The UppASD team",
+      "author_email": "uppasd@physics.uu.se",
+      "version": "0.1.0a0",
+      "description": "AiiDA plugin for the atomistic spin dynamics code UppASD",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Natural Language :: English",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0b3,<2.0.0"
+  },
+  "vasp": {
+    "name": "aiida-vasp",
+    "entry_point": "vasp",
+    "state": "development",
+    "pip_url": "aiida-vasp",
+    "code_home": "https://github.com/aiida-vasp/aiida-vasp",
+    "plugin_info": [
+      "setuptools",
+      {
+        "author": "Rico H\u00e4uselmann",
+        "author_email": "haeuselm@epfl.ch",
+        "classifiers": [
+          "Development Status :: 3 - Alpha",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Topic :: Scientific/Engineering :: Physics"
+        ],
+        "description": "AiiDA Plugin for running VASP calculations.",
+        "entry_points": {
+          "console_scripts": [
+            "mock-vasp = aiida_vasp.commands.mock_vasp:mock_vasp"
+          ],
+          "aiida.calculations": [
+            "vasp.vasp = aiida_vasp.calcs.vasp:VaspCalculation",
+            "vasp.vasp2w90 = aiida_vasp.calcs.vasp2w90:Vasp2w90Calculation"
+          ],
+          "aiida.cmdline.data": [
+            "vasp-potcar = aiida_vasp.commands.potcar:potcar"
+          ],
+          "aiida.data": [
+            "vasp.archive = aiida_vasp.data.archive:ArchiveData",
+            "vasp.chargedensity = aiida_vasp.data.chargedensity:ChargedensityData",
+            "vasp.wavefun = aiida_vasp.data.wavefun:WavefunData",
+            "vasp.potcar = aiida_vasp.data.potcar:PotcarData",
+            "vasp.potcar_file = aiida_vasp.data.potcar:PotcarFileData",
+            "vasp.paw = aiida_vasp.data.paw:LegacyPawData"
+          ],
+          "aiida.parsers": [
+            "vasp.vasp = aiida_vasp.parsers.vasp:VaspParser",
+            "vasp.vasp2w90 = aiida_vasp.parsers.vasp2w90:Vasp2w90Parser",
+            "vasp.pymatgen = aiida_vasp.parsers.pymatgen_vasp:PymatgenParser"
+          ],
+          "aiida.workflows": [
+            "vasp.base = aiida_vasp.workflows.base:VaspBaseWf",
+            "vasp.relax = aiida_vasp.workflows.relax:VaspRelaxWf",
+            "vasp.legacy.scf = aiida_vasp.workflows.legacy.scf:ScfWorkflow",
+            "vasp.legacy.nscf = aiida_vasp.workflows.legacy.nscf:NscfWorkflow",
+            "vasp.legacy.projections = aiida_vasp.workflows.legacy.projections:ProjectionsWorkflow",
+            "vasp.legacy.autowindows = aiida_vasp.workflows.legacy.autowindows:AutowindowsWorkflow",
+            "vasp.legacy.wannier = aiida_vasp.workflows.legacy.wannier:WannierWorkflow",
+            "vasp.legacy.windows = aiida_vasp.workflows.legacy.windows:WindowsWorkflow"
+          ]
+        },
+        "extras_require": {
+          "dev": [
+            "pre-commit",
+            "prospector == 0.12.11",
+            "pylint == 1.9.3",
+            "flake8",
+            "yapf",
+            "coverage",
+            "pytest",
+            "pytest-cov",
+            "pgtest >= 1.1.0",
+            "packaging"
+          ],
+          "graphs": [
+            "matplotlib"
+          ],
+          "regen_default_paws": [
+            "lxml"
+          ],
+          "wannier": [
+            "aiida-wannier90"
+          ]
+        },
+        "include_package_data": true,
+        "install_requires": [
+          "aiida-core[atomic_tools] >= 0.11.0",
+          "ase",
+          "scipy",
+          "pymatgen",
+          "subprocess32",
+          "click",
+          "chainmap",
+          "six",
+          "pyparsing",
+          "py",
+          "lxml",
+          "packaging",
+          "parsevasp >= 0.2.18"
+        ],
+        "license": "MIT License, see LICENSE.txt file.",
+        "name": "aiida-vasp",
+        "reentry_register": true,
+        "scripts": [
+          "utils/runwf.py"
+        ],
+        "setup_requires": [
+          "reentry"
+        ],
+        "url": "https://github.com/aiida-vasp/aiida-vasp",
+        "version": "0.2.4"
+      }
+    ],
+    "documentation_url": "https://aiida-vasp.readthedocs.io/",
+    "package_name": "aiida_vasp",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "console_scripts": [
+        "mock-vasp = aiida_vasp.commands.mock_vasp:mock_vasp"
+      ],
+      "aiida.calculations": [
+        "vasp.vasp = aiida_vasp.calcs.vasp:VaspCalculation",
+        "vasp.vasp2w90 = aiida_vasp.calcs.vasp2w90:Vasp2w90Calculation"
+      ],
+      "aiida.cmdline.data": [
+        "vasp-potcar = aiida_vasp.commands.potcar:potcar"
+      ],
+      "aiida.data": [
+        "vasp.archive = aiida_vasp.data.archive:ArchiveData",
+        "vasp.chargedensity = aiida_vasp.data.chargedensity:ChargedensityData",
+        "vasp.wavefun = aiida_vasp.data.wavefun:WavefunData",
+        "vasp.potcar = aiida_vasp.data.potcar:PotcarData",
+        "vasp.potcar_file = aiida_vasp.data.potcar:PotcarFileData",
+        "vasp.paw = aiida_vasp.data.paw:LegacyPawData"
+      ],
+      "aiida.parsers": [
+        "vasp.vasp = aiida_vasp.parsers.vasp:VaspParser",
+        "vasp.vasp2w90 = aiida_vasp.parsers.vasp2w90:Vasp2w90Parser",
+        "vasp.pymatgen = aiida_vasp.parsers.pymatgen_vasp:PymatgenParser"
+      ],
+      "aiida.workflows": [
+        "vasp.base = aiida_vasp.workflows.base:VaspBaseWf",
+        "vasp.relax = aiida_vasp.workflows.relax:VaspRelaxWf",
+        "vasp.legacy.scf = aiida_vasp.workflows.legacy.scf:ScfWorkflow",
+        "vasp.legacy.nscf = aiida_vasp.workflows.legacy.nscf:NscfWorkflow",
+        "vasp.legacy.projections = aiida_vasp.workflows.legacy.projections:ProjectionsWorkflow",
+        "vasp.legacy.autowindows = aiida_vasp.workflows.legacy.autowindows:AutowindowsWorkflow",
+        "vasp.legacy.wannier = aiida_vasp.workflows.legacy.wannier:WannierWorkflow",
+        "vasp.legacy.windows = aiida_vasp.workflows.legacy.windows:WindowsWorkflow"
+      ]
+    },
+    "metadata": {
+      "author": "Rico H\u00e4uselmann",
+      "author_email": "haeuselm@epfl.ch",
+      "version": "0.2.4",
+      "description": "AiiDA Plugin for running VASP calculations.",
+      "classifiers": [
+        "Development Status :: 3 - Alpha",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Topic :: Scientific/Engineering :: Physics"
+      ]
+    },
+    "aiida_version": ">=0.11.0"
+  },
+  "wannier90": {
+    "name": "aiida-wannier90",
+    "entry_point": "wannier90",
+    "state": "stable",
+    "pip_url": "aiida-wannier90",
+    "plugin_info": [
+      "setuptools",
+      {
+        "entry_points": {
+          "aiida.calculations": [
+            "wannier90.wannier90 = aiida_wannier90.calculations:Wannier90Calculation"
+          ],
+          "aiida.parsers": [
+            "wannier90.wannier90 = aiida_wannier90.parsers:Wannier90Parser"
+          ],
+          "aiida.data": []
+        },
+        "extras_require": {
+          "test": [
+            "pytest",
+            "aiida-pytest",
+            "pymatgen"
+          ],
+          "docs": [
+            "sphinx",
+            "sphinx-rtd-theme"
+          ],
+          "dev": [
+            "pre-commit",
+            "yapf==0.19"
+          ]
+        },
+        "name": "aiida-wannier90",
+        "license": "MIT",
+        "author": "Dominik Gresch, Antimo Marrazzo, Daniel Marchand, Giovanni Pizzi & The AiiDA Team.",
+        "author_email": "developers@aiida.net",
+        "install_requires": [
+          "aiida-core>=0.9.1"
+        ],
+        "version": "1.0.0",
+        "keywords": "wannier90 AiiDA workflows plugin",
+        "classifiers": [
+          "Development Status :: 5 - Production/Stable",
+          "Environment :: Plugins",
+          "Intended Audience :: Science/Research",
+          "License :: OSI Approved :: MIT License",
+          "Programming Language :: Python :: 2.7",
+          "Topic :: Scientific/Engineering :: Physics"
+        ],
+        "description": "AiiDA Plugin for Wannier90"
+      }
+    ],
+    "code_home": "https://github.com/aiidateam/aiida-wannier90",
+    "documentation_url": "https://aiida-wannier90.readthedocs.io/",
+    "package_name": "aiida_wannier90",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "wannier90.wannier90 = aiida_wannier90.calculations:Wannier90Calculation"
+      ],
+      "aiida.parsers": [
+        "wannier90.wannier90 = aiida_wannier90.parsers:Wannier90Parser"
+      ],
+      "aiida.data": []
+    },
+    "metadata": {
+      "author": "Dominik Gresch, Antimo Marrazzo, Daniel Marchand, Giovanni Pizzi & The AiiDA Team.",
+      "author_email": "developers@aiida.net",
+      "version": "1.0.0",
+      "description": "AiiDA Plugin for Wannier90",
+      "classifiers": [
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Plugins",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 2.7",
+        "Topic :: Scientific/Engineering :: Physics"
+      ]
+    },
+    "aiida_version": ">=0.9.1"
+  },
+  "widgets": {
+    "name": "aiidalab-widgets-base",
+    "state": "development",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiidalab-widgets-base",
+        "author_email": "aiidateam@gmail.com",
+        "url": "https://github.com/aiidalab/aiidalab-widgets-base",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python"
+        ],
+        "install_requires": [
+          "aiida-core[jupyter] >= 0.11",
+          "ase",
+          "numpy",
+          "ipywidgets",
+          "fileupload",
+          "nglview"
+        ],
+        "extras_require": {
+          "testing": [
+            "aiida-core[testing]"
+          ],
+          "pre-commit": [
+            "pre-commit",
+            "yapf",
+            "prospector",
+            "pylint"
+          ],
+          "docs": [
+            "sphinx"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/aiidalab/aiidalab-widgets-base",
+    "pip_url": "aiidalab-widgets-base",
+    "package_name": "aiidalab_widgets_base",
+    "hosted_on": "github.com",
+    "entry_points": {},
+    "metadata": {
+      "author": "",
+      "author_email": "aiidateam@gmail.com",
+      "version": "",
+      "description": "",
+      "classifiers": [
+        "Programming Language :: Python"
+      ]
+    },
+    "aiida_version": ">=0.11"
+  },
+  "yambo": {
+    "name": "aiida-yambo",
+    "entry_point": "yambo",
+    "state": "development",
+    "pip_url": "aiida-yambo",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-yambo",
+        "author": "Michael Atambo, Antimo Marrazzo, Prandini Gianluca",
+        "author_email": "m.atambo@nano.cnr.it",
+        "description": "YAMBO code Plugin for AiiDA",
+        "url": "https://github.com/yambo-code/yambo-aiida",
+        "license": "MIT",
+        "classifiers": [
+          "Programming Language :: Python",
+          "License :: OSI Approved :: MIT License",
+          "Environment :: Plugins",
+          "Topic :: Scientific/Engineering :: Physics"
+        ],
+        "version": "0.2.5",
+        "extras_require": {
+          "docs": [
+            "Sphinx",
+            "docutils",
+            "sphinx_rtd_theme"
+          ]
+        },
+        "install_requires": [
+          "aiida_core[docs,atomic_tools]>=1.0.0a2",
+          "aiida-quantumespresso",
+          "reentry>=1.0.2"
+        ],
+        "dependency_links": [
+          "git+https://github.com/aiidateam/aiida_core.git@b2e37749ab2781099df7b7bb15a603599ccdafdb#egg=aiida_core",
+          "git+https://github.com/aiidateam/aiida-quantumespresso.git@b1e074f31cc604b43c7803344cf2cee45503c6df#egg=aiida_quantumespresso"
+        ],
+        "keywords": "yambo aiida workflows",
+        "entry_points": {
+          "aiida.calculations": [
+            "yambo.yambo =  aiida_yambo.calculations.gw:YamboCalculation"
+          ],
+          "aiida.parsers": [
+            "yambo.yambo = aiida_yambo.parsers.parsers:YamboParser"
+          ],
+          "aiida.data": [],
+          "console_scripts": [
+            "plotyamboconv = aiida_yambo.commands.plotting:plotconv",
+            "mock_qe = aiida_yambo.commands.mocks:mock_qe",
+            "mock_yambo = aiida_yambo.commands.mocks:mock_yambo",
+            "mock_p2y = aiida_yambo.commands.mocks:mock_p2y"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/yambo-code/yambo-aiida/",
+    "package_name": "aiida_yambo",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "yambo.yambo =  aiida_yambo.calculations.gw:YamboCalculation"
+      ],
+      "aiida.parsers": [
+        "yambo.yambo = aiida_yambo.parsers.parsers:YamboParser"
+      ],
+      "aiida.data": [],
+      "console_scripts": [
+        "plotyamboconv = aiida_yambo.commands.plotting:plotconv",
+        "mock_qe = aiida_yambo.commands.mocks:mock_qe",
+        "mock_yambo = aiida_yambo.commands.mocks:mock_yambo",
+        "mock_p2y = aiida_yambo.commands.mocks:mock_p2y"
+      ]
+    },
+    "metadata": {
+      "author": "Michael Atambo, Antimo Marrazzo, Prandini Gianluca",
+      "author_email": "m.atambo@nano.cnr.it",
+      "version": "0.2.5",
+      "description": "YAMBO code Plugin for AiiDA",
+      "classifiers": [
+        "Programming Language :: Python",
+        "License :: OSI Approved :: MIT License",
+        "Environment :: Plugins",
+        "Topic :: Scientific/Engineering :: Physics"
+      ]
+    },
+    "aiida_version": ">=1.0.0a2"
+  },
+  "z2pack": {
+    "name": "aiida-z2pack",
+    "entry_point": "z2pack",
+    "state": "registered",
+    "code_home": "https://github.com/AntimoMarrazzo/aiida-z2pack",
+    "pip_url": "git+https://github.com/AntimoMarrazzo/aiida-z2pack",
+    "plugin_info": null,
+    "package_name": "aiida_z2pack",
+    "hosted_on": "github.com",
+    "entry_points": {},
+    "metadata": null,
+    "aiida_version": null
+  },
+  "zeopp": {
+    "name": "aiida-zeopp",
+    "entry_point": "zeopp",
+    "state": "stable",
+    "plugin_info": [
+      "setuptools",
+      {
+        "name": "aiida-zeopp",
+        "author": "Leopold Talirz",
+        "author_email": "leopold.talirz@epfl.ch",
+        "description": "AiiDA plugin for zeo++",
+        "url": "https://github.com/ltalirz/aiida-zeopp",
+        "license": "Creative Commons",
+        "classifiers": [
+          "Programming Language :: Python",
+          "Framework :: AiiDA"
+        ],
+        "version": "1.0.0",
+        "entry_points": {
+          "aiida.calculations": [
+            "zeopp.network = aiida_zeopp.calculations.network:NetworkCalculation"
+          ],
+          "aiida.parsers": [
+            "zeopp.network = aiida_zeopp.parsers.network:NetworkParser"
+          ],
+          "aiida.data": [
+            "zeopp.parameters = aiida_zeopp.data.parameters:NetworkParameters"
+          ],
+          "console_scripts": [
+            "zeopp-submit = aiida_zeopp.console_scripts.data_cli:cli"
+          ],
+          "aiida.workflows": []
+        },
+        "setup_requires": [
+          "reentry"
+        ],
+        "reentry_register": true,
+        "install_requires": [
+          "aiida-core >=1.0.0b6,<2.0.0",
+          "pycifrw >= 4.2",
+          "numpy < 1.17",
+          "pymatgen <= 2018.12.12",
+          "monty==2.0.4",
+          "voluptuous",
+          "six"
+        ],
+        "extras_require": {
+          "testing": [
+            "pgtest==1.2.0",
+            "pytest>=4.4,<5.0.0",
+            "pytest-cov>=2.6.1,<3.0.0",
+            "coverage"
+          ],
+          "pre-commit": [
+            "astroid==1.6.6; python_version<'3.0'",
+            "astroid==2.2.5; python_version>='3.0'",
+            "pre-commit==1.17.0",
+            "yapf==0.28.0",
+            "prospector==1.1.7",
+            "pylint-django==0.11.1; python_version<'3.0'",
+            "pylint==1.9.4; python_version<'3.0'",
+            "pylint==2.3.1; python_version>='3.0'"
+          ]
+        }
+      }
+    ],
+    "code_home": "https://github.com/ltalirz/aiida-zeopp",
+    "pip_url": "aiida-zeopp",
+    "package_name": "aiida_zeopp",
+    "hosted_on": "github.com",
+    "entry_points": {
+      "aiida.calculations": [
+        "zeopp.network = aiida_zeopp.calculations.network:NetworkCalculation"
+      ],
+      "aiida.parsers": [
+        "zeopp.network = aiida_zeopp.parsers.network:NetworkParser"
+      ],
+      "aiida.data": [
+        "zeopp.parameters = aiida_zeopp.data.parameters:NetworkParameters"
+      ],
+      "console_scripts": [
+        "zeopp-submit = aiida_zeopp.console_scripts.data_cli:cli"
+      ],
+      "aiida.workflows": []
+    },
+    "metadata": {
+      "author": "Leopold Talirz",
+      "author_email": "leopold.talirz@epfl.ch",
+      "version": "1.0.0",
+      "description": "AiiDA plugin for zeo++",
+      "classifiers": [
+        "Programming Language :: Python",
+        "Framework :: AiiDA"
+      ]
+    },
+    "aiida_version": ">=1.0.0b6,<2.0.0"
+  }
+}

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""Fetch metadata from plugins and dump it to temporary JSON file.
+
+This fetches metadata from plugins defined using different build systems
+ * setuptools/pip: setup.json
+ * poetry: pyproject.toml
+ * flit: pyproject.toml
+"""
+from __future__ import absolute_import
+from __future__ import print_function
+
+
+def test_entrypoint(capsys):
+    """Test entry point checks.
+
+    The registry should check only entry points from the 'aiida.' groups.
+    """
+    from . import TEST_DATA
+    from aiida_registry.fetch_metadata import validate_plugin_entry_points
+
+    # aiida-gulp example contains 'reaxff' entry point in 'gulp.potentials' group
+    validate_plugin_entry_points(TEST_DATA['crystal17'])
+
+    captured = capsys.readouterr()
+    # should not warn about 'reaxff' not starting with 'gulp'
+    assert 'reaxff' not in captured.out


### PR DESCRIPTION
fix #99 

plugin registry was complaining about any entry point that didn't start
with the correct entry point prefix.
we should only be checking entry-point groups defined by AiiDA.