### PR TITLE
add --pre to install cmd for pre-release versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
       COMMIT_AUTHOR_EMAIL: deploy@travis-ci.org
     steps:
     - uses: actions/checkout@v1
+    - name: Install prerequisites
+      run: pip install --upgrade wheel setuptools
     - name: Install
       run: pip install -e .
     - name: fetch metadata

--- a/aiida_registry/mod/templates/main_index.html
+++ b/aiida_registry/mod/templates/main_index.html
@@ -31,7 +31,7 @@
         {% if plugin.metadata.description %}
         <p class=description>{{plugin.metadata.description}}</p>
         {% endif %}
-        <p class="currentstate">Current state:
+        <p class="currentstate">State:
             <span class="classbox">{{  plugin.state }}
                 <span class="tooltiptext">
                     {{ plugin.state_dict[plugin.state] }}

--- a/aiida_registry/mod/templates/singlepage.html
+++ b/aiida_registry/mod/templates/singlepage.html
@@ -7,10 +7,10 @@
 
 {% block body %}
 <main>
-        <h1 class="plugin-header">
-            Details for AiiDA plugin &quot;<a href="{{code_home}}">{{name}}</a>&quot;
-        </h1>
-        <p><a href="../index.html">&lt; Go back to the aiida-registry plugin summary</a></p>
+    <h1 class="plugin-header">
+        AiiDA plugin &quot;<a href="{{code_home}}">{{name}}</a>&quot;
+    </h1>
+    <p><a href="../index.html">&lt; Go back to the plugin registry index</a></p>
 
     <h2>General information</h2>
     <div>
@@ -22,9 +22,19 @@
                 </span>
             </span>
         </p>
+        {%  if metadata.description %}
+        <p>
+            <strong>Short description</strong>: {{ metadata.description }}
+        </p>
+        {% endif %}
+        {%  if pip_url %}
+        <p>
+            <strong>How to install</strong>: <code>{{ pip_install_cmd }}</code>
+        </p>
+        {% endif %}
 
         <p>
-            <a href="{{ code_home }}" target="_blank">Go to the plugin code homepage</a>
+            <strong>Source code</strong>: <a href="{{ code_home }}" target="_blank">Go to the source code repository</a>
         </p>
     </div>
 
@@ -34,7 +44,7 @@
         <p>
     {% else %}
         <p>
-            <strong>Documentation</strong>: Documentation not provided by the plugin author
+            <strong>Documentation</strong>: No documentation provided by the plugin author
         <p>
     {% endif %}
 
@@ -52,16 +62,6 @@
             <strong>Contact</strong>: <a href="mailto:{{ metadata.author_email }}">{{ metadata.author_email }}</a>
         </p>
         {% endif %}
-        {%  if metadata.description %}
-        <p>
-            <strong>Short description</strong>: {{ metadata.description }}
-        </p>
-        {% endif %}
-        {%  if pip_url %}
-        <p>
-            <strong>How to install</strong>: <code>pip install {{ pip_url }}</code>
-        </p>
-        {% endif %}
         <p>
             <strong>How to use from python</strong>: <code>import {{ package_name }}</code>
         </p>
@@ -73,8 +73,8 @@
         </p>
 
         {% if summaryinfo %}
-        <h3>Summary of the entry points</h3>
-        This plugin contains: <br>
+        <h3>Entry points provided by the plugin</h3>
+
         {% for summaryinfoelem in summaryinfo %}
         <span class="badge">
             <span class="badge-left {{summaryinfoelem.colorclass}}">{{summaryinfoelem.text}}</span>
@@ -82,8 +82,6 @@
         </span>
         {% endfor %}
         {% endif %}
-
-        <h3>Available entry points</h3>
         {% if entry_points %}
 
             {% for entrypointtype, entrypointlist in entry_points.items() %}
@@ -110,9 +108,9 @@
     {% else %}
     <div id='description'>
         <p>
-            Detailed info for this package could not be obtained.
-            Ask the plugin developers to check their <code>setup.json</code> file
-            in the plugin source code.
+            Detailed information for this package could not be obtained.
+            Ask the plugin author to add a <code>setup.json</code> file
+            to the plugin source code.
         </p>
     </div>
     {% endif %}

--- a/aiida_registry/static/css/style.css
+++ b/aiida_registry/static/css/style.css
@@ -114,10 +114,22 @@ h2 {
 
 
 h3 {
-    margin-bottom: 3px;
-    margin-top: 21px;
+    padding-top: 20px;
+    padding-bottom: 5px;
+    margin:0;
     font-size: 120%;
     color: #005;
+}
+
+h4 {
+    padding-top: 20px;
+    padding-bottom: 5px;
+    margin:0;
+}
+
+ul {
+    margin-block-start: 0.1em;
+    margin-block-end: 0.1em;
 }
 
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -8,6 +8,7 @@ This fetches metadata from plugins defined using different build systems
 """
 from __future__ import absolute_import
 from __future__ import print_function
+from . import TEST_DATA
 
 
 def test_entrypoint(capsys):
@@ -15,7 +16,6 @@ def test_entrypoint(capsys):
 
     The registry should check only entry points from the 'aiida.' groups.
     """
-    from . import TEST_DATA
     from aiida_registry.fetch_metadata import validate_plugin_entry_points
 
     # aiida-gulp example contains 'reaxff' entry point in 'gulp.potentials' group
@@ -24,3 +24,14 @@ def test_entrypoint(capsys):
     captured = capsys.readouterr()
     # should not warn about 'reaxff' not starting with 'gulp'
     assert 'reaxff' not in captured.out
+
+
+def test_pip_install_cmd():
+    """Test pip install command to display."""
+    from aiida_registry.make_pages import get_pip_install_cmd
+
+    # aiida-crystal17 is beta version
+    assert '--pre' in get_pip_install_cmd(TEST_DATA['crystal17'])
+
+    # aiida-core is stable version
+    assert '--pre' not in get_pip_install_cmd(TEST_DATA['core'])


### PR DESCRIPTION
fix #105 

pip won't install pre-releases by default.
if the latest version of a plugin is a pre-release, add --pre option to
pip installation command

Also:
  * adapt css style
  * add test