### PR TITLE
plugin aiida-hea renamed to aiida-ce

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -327,14 +327,13 @@
         "code_home": "https://github.com/uppasd/aiida-uppasd",
         "documentation_url": "https://github.com/uppasd/aiida-uppasd/blob/master/README.md"
     },
-    "hea":{
-        "name": "aiida-hea",
-        "entry_point": "hea",
-        "state": "registered",
-        "code_home": "https://github.com/unkcpz/aiida-hea",
-        "plugin_info": "https://raw.github.com/unkcpz/aiida-hea/master/setup.json",
-        "pip_url": "git+https://github.com/unkcpz/aiida-hea",
-        "documentation_url": "https://aiida-hea.readthedocs.io/"
+    "ce":{
+        "name": "aiida-ce",
+        "entry_point": "ce",
+        "state": "development",
+        "code_home": "https://github.com/unkcpz/aiida-ce",
+        "plugin_info": "https://raw.github.com/unkcpz/aiida-ce/master/setup.json",
+        "pip_url": "git+https://github.com/unkcpz/aiida-ce"
     },
     "porousmaterials": {
         "name": "aiida-porousmaterials",


### PR DESCRIPTION
The purpose of aiida-hea is partly duplicated with aiida-alloy. After discuss with the developers of aiida-alloy, I decided to rename aiida-hea to aiida-ce which only contains the plugins in doing the cluster expansion through the [icet](https://icet.materialsmodeling.org/index.html).

I've already started  development and implemented some available features.