### PR TITLE
re-enable periodic build on github actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,7 @@ on:
   schedule:
   # See https://help.github.com/en/actions/automating-your-workflow-with-github-actions/events-that-trigger-workflows#scheduled-events-schedule
   # run every day at 21:00 UTC
-  #- cron: "0 21 * * *"
-  - cron: "0 21 * 10 *"  # disabled, only runs in october
+  - cron: "0 21 * * *"
 
 jobs:
   daily_build:


### PR DESCRIPTION
fix #100

it seems like the bug preventing a github actions build from triggering
an update of github pages has been fixed

https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/46527#M6555

Re-enabling.