### PR TITLE
adding new aiida-orca + fixing pip_url for aiida-porousmaterials

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -340,7 +340,7 @@
         "state": "development",
         "plugin_info": "https://raw.githubusercontent.com/pzarabadip/aiida-porousmaterials/master/setup.json",
         "code_home": "https://github.com/pzarabadip/aiida-porousmaterials",
-        "pip_url": "git+https://github.com/pzarabadip/aiida-porousmaterials"
+        "pip_url": "aiida-porousmaterials"
     },
     "plumed": {
         "name": "aiida-plumed",
@@ -382,5 +382,13 @@
         "plugin_info": "https://raw.github.com/nanotech-empa/aiida-gaussian/master/setup.json",
         "code_home": "https://github.com/nanotech-empa/aiida-gaussian",
         "pip_url": "aiida-gaussian"
+    },
+    "orca": {
+        "name": "aiida-orca",
+        "entry_point_prefix": "orca",
+        "state": "development",
+        "plugin_info": "https://raw.githubusercontent.com/pzarabadip/aiida-orca/master/setup.json",
+        "code_home": "https://github.com/pzarabadip/aiida-orca",
+        "pip_url": "git+https://github.com/pzarabadip/aiida-orca"
     }
 }


### PR DESCRIPTION
This PR contains brings two changes in `plugins.json`:

* I have developed a new plugin for `ORCA` and added this to the registry. This version works but it is under development to add more parsing options while testing it in real-world calculations. I will activate GitHub actions and put more tests in next few weeks.

* there is a minor change in my other plugin, i.e. `aiida-porousmaterials` where I have added the `pip_url`.
