### PR TITLE
Adding aiida-fireworks-scheduler to the repostiory

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -481,7 +481,7 @@
         "code_home": "https://github.com/pzarabadip/aiida-metavo-scheduler",
         "pip_url": "git+https://github.com/pzarabadip/aiida-metavo-scheduler"
     },
-    "aiida-fireworks-scheduler": {
+    "fireworks-scheduler": {
         "name": "aiida-fireworks-scheduler",
         "entry_point_prefix": "fireworks_scheduler",
         "development_status": "beta",

--- a/plugins.json
+++ b/plugins.json
@@ -481,13 +481,13 @@
         "code_home": "https://github.com/pzarabadip/aiida-metavo-scheduler",
         "pip_url": "git+https://github.com/pzarabadip/aiida-metavo-scheduler"
     },
-    "fireworks-scheduler": {
-        "name": "aiida-fireengine",
-        "entry_point_prefix": "fireengine",
+    "aiida-fireworks-scheduler": {
+        "name": "aiida-fireworks-scheduler",
+        "entry_point_prefix": "fireworks_scheduler",
         "development_status": "beta",
-        "plugin_info": "https://github.com/zhubonan/aiida-fireengine/blob/master/setup.json",
-        "code_home": "https://github.com/zhubonan/aiida-fireengine",
-        "pip_url": "git+https://https://github.com/zhubonan/aiida-fireengine",
-        "documentation_url": "https://aiida-fireengine.readthedocs.io"
+        "plugin_info": "https://github.com/zhubonan/aiida-fireworks-scheduler/blob/master/setup.json",
+        "code_home": "https://github.com/zhubonan/aiida-fireworks-scheduler",
+        "pip_url": "git+https://https://github.com/zhubonan/aiida-fireworks-scheduler",
+        "documentation_url": "https://aiida-fireworks-scheduler.readthedocs.io"
     }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -480,5 +480,14 @@
         "plugin_info": "https://github.com/pzarabadip/aiida-metavo-scheduler/blob/master/setup.json",
         "code_home": "https://github.com/pzarabadip/aiida-metavo-scheduler",
         "pip_url": "git+https://github.com/pzarabadip/aiida-metavo-scheduler"
+    },
+    "fireworks-scheduler": {
+        "name": "aiida-fireengine",
+        "entry_point_prefix": "fireengine",
+        "development_status": "beta",
+        "plugin_info": "https://github.com/zhubonan/aiida-fireengine/blob/master/setup.json",
+        "code_home": "https://github.com/zhubonan/aiida-fireengine",
+        "pip_url": "git+https://https://github.com/zhubonan/aiida-fireengine",
+        "documentation_url": "https://aiida-fireengine.readthedocs.io"
     }
 }


### PR DESCRIPTION
This plugin provided a scheduler that does not interface to any scheduler installed onto the remote computer. Instead, it interfaces
with the `fireworks` package to allow launching AiiDA CalcJobs to run on the remote computer in a more flexible way. For example, multiple AiiDA jobs can be encapsulated into a single resource allocation (of one or
more computing nodes) to run in serial/parallel.