### PR TITLE
Fix plugin_info links 

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -481,7 +481,7 @@
         "code_home": "https://github.com/pzarabadip/aiida-metavo-scheduler",
         "pip_url": "git+https://github.com/pzarabadip/aiida-metavo-scheduler"
     },
-    "aiida-fireworks-scheduler": {
+    "fireworks-scheduler": {
         "name": "aiida-fireworks-scheduler",
         "entry_point_prefix": "fireworks_scheduler",
         "development_status": "beta",

--- a/plugins.json
+++ b/plugins.json
@@ -481,13 +481,13 @@
         "code_home": "https://github.com/pzarabadip/aiida-metavo-scheduler",
         "pip_url": "git+https://github.com/pzarabadip/aiida-metavo-scheduler"
     },
-    "fireworks-scheduler": {
-        "name": "aiida-fireengine",
-        "entry_point_prefix": "fireengine",
+    "aiida-fireworks-scheduler": {
+        "name": "aiida-fireworks-scheduler",
+        "entry_point_prefix": "fireworks_scheduler",
         "development_status": "beta",
-        "plugin_info": "https://github.com/zhubonan/aiida-fireengine/blob/master/setup.json",
-        "code_home": "https://github.com/zhubonan/aiida-fireengine",
-        "pip_url": "git+https://https://github.com/zhubonan/aiida-fireengine",
-        "documentation_url": "https://aiida-fireengine.readthedocs.io"
+        "plugin_info": "https://github.com/zhubonan/aiida-fireworks-scheduler/blob/master/setup.json",
+        "code_home": "https://github.com/zhubonan/aiida-fireworks-scheduler",
+        "pip_url": "git+https://https://github.com/zhubonan/aiida-fireworks-scheduler",
+        "documentation_url": "https://aiida-fireworks-scheduler.readthedocs.io"
     }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -477,7 +477,7 @@
         "name": "aiida-metavo-scheduler",
         "entry_point_prefix": "aiida_metavo_scheduler",
         "development_status": "stable",
-        "plugin_info": "https://github.com/pzarabadip/aiida-metavo-scheduler/blob/master/setup.json",
+        "plugin_info": "https://raw.github.com/pzarabadip/aiida-metavo-scheduler/master/setup.json",
         "code_home": "https://github.com/pzarabadip/aiida-metavo-scheduler",
         "pip_url": "git+https://github.com/pzarabadip/aiida-metavo-scheduler"
     },
@@ -485,7 +485,7 @@
         "name": "aiida-fireworks-scheduler",
         "entry_point_prefix": "fireworks_scheduler",
         "development_status": "beta",
-        "plugin_info": "https://github.com/zhubonan/aiida-fireworks-scheduler/blob/master/setup.json",
+        "plugin_info": "https://raw.github.com/zhubonan/aiida-fireworks-scheduler/master/setup.json",
         "code_home": "https://github.com/zhubonan/aiida-fireworks-scheduler",
         "pip_url": "git+https://https://github.com/zhubonan/aiida-fireworks-scheduler",
         "documentation_url": "https://aiida-fireworks-scheduler.readthedocs.io"

--- a/plugins.json
+++ b/plugins.json
@@ -480,5 +480,14 @@
         "plugin_info": "https://github.com/pzarabadip/aiida-metavo-scheduler/blob/master/setup.json",
         "code_home": "https://github.com/pzarabadip/aiida-metavo-scheduler",
         "pip_url": "git+https://github.com/pzarabadip/aiida-metavo-scheduler"
+    },
+    "fireworks-scheduler": {
+        "name": "aiida-fireengine",
+        "entry_point_prefix": "fireengine",
+        "development_status": "beta",
+        "plugin_info": "https://github.com/zhubonan/aiida-fireengine/blob/master/setup.json",
+        "code_home": "https://github.com/zhubonan/aiida-fireengine",
+        "pip_url": "git+https://https://github.com/zhubonan/aiida-fireengine",
+        "documentation_url": "https://aiida-fireengine.readthedocs.io"
     }
 }


### PR DESCRIPTION
Fixing the `plugin_info` links.

Just realised that I used the wrong link for `plugin_info`. For the json files, the "raw.github.com" link should be used. 

The fix is also applied to the `aiida-metavo-scheduler` entry. I copied from it in the first place...