### PR TITLE
Change branch of aiida-strain to 'trunk'.

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -309,7 +309,7 @@
         "name": "aiida-strain",
         "entry_point_prefix": "strain",
         "development_status": "stable",
-        "plugin_info": "https://raw.githubusercontent.com/greschd/aiida-strain/master/setup.json",
+        "plugin_info": "https://raw.githubusercontent.com/greschd/aiida-strain/trunk/setup.json",
         "code_home": "https://github.com/greschd/aiida-strain",
         "documentation_url": "https://aiida-strain.readthedocs.io",
         "pip_url": "aiida-strain"
@@ -448,15 +448,15 @@
         "pip_url": "git+https://github.com/atztogo/aiida-nims-scheduler",
         "documentation_url": "https://github.com/atztogo/aiida-nims-scheduler"
     },
-		"aiida-cusp": {
-				"name": "aiida-cusp",
-    		"entry_point_prefix": "cusp",
-    		"development_status": "beta",
-	  		"plugin_info": "https://raw.githubusercontent.com/aiida-cusp/aiida-cusp/master/setup.json",
-    		"code_home": "https://github.com/aiida-cusp/aiida-cusp",
-				"pip_url": "https://pypi.org/project/aiida-cusp",
-	  		"documentation_url": "https://aiida-cusp.readthedocs.io"
-	},
+    "aiida-cusp": {
+        "name": "aiida-cusp",
+        "entry_point_prefix": "cusp",
+        "development_status": "beta",
+        "plugin_info": "https://raw.githubusercontent.com/aiida-cusp/aiida-cusp/master/setup.json",
+        "code_home": "https://github.com/aiida-cusp/aiida-cusp",
+        "pip_url": "https://pypi.org/project/aiida-cusp",
+        "documentation_url": "https://aiida-cusp.readthedocs.io"
+    },
     "sshonly": {
         "name": "aiida-sshonly",
         "entry_point_prefix": "sshonly",


### PR DESCRIPTION
Fixes https://github.com/greschd/aiida-strain/issues/5 ;)

I switched to a simpler "single `trunk` + tags" branching model instead of maintaining separate `master` and `develop`. This means that the `trunk/setup.json` will not always reflect the latest released version on PyPI.

Is this a problem for how the registry operates? I guess this ties into a side discussion from #132 on whether this data should be fetched from PyPI instead of the repositories.

The whitespace change was my editor reformatting JSON, I can revert that if desired.

As a total side note, are these daily builds _supposed to_ run on forks also, or do we need to [add a guard to the `ci.yml` and `webpage.yml`](https://github.com/aiidateam/aiida-quantumespresso/blob/1ad9842942312879c31555693646e8475eaec455/.github/workflows/develop.yml#L11)?

Ping @ltalirz 