### PR TITLE
fix: fetch metadata should not crash

### DIFF
--- a/aiida_registry/fetch_metadata.py
+++ b/aiida_registry/fetch_metadata.py
@@ -73,7 +73,7 @@ def fetch_plugin_info(url):
     except Exception:  # pylint: disable=broad-except
         report(
             '  > WARNING! Unable to retrieve plugin info from: {}'.format(url))
-        report(traceback.print_exc(file=sys.stdout))
+        report(traceback.format_exc())
         return None
 
     if 'pyproject.toml' in url:

--- a/aiida_registry/make_pages.py
+++ b/aiida_registry/make_pages.py
@@ -152,7 +152,7 @@ def get_pip_install_cmd(plugin_data):
         if any([version.find(p_id) != -1 for p_id in pre_releases]):
             return 'pip install --pre {}'.format(pip_url)
         return 'pip install {}'.format(pip_url)
-    except KeyError:
+    except (KeyError, TypeError):
         return 'pip install {}'.format(pip_url)
 
 


### PR DESCRIPTION
fetch metadata crashed when an exception was encountered during fetch of
the plugin metadata (because `print_exc` actually returns `None`).