### PR TITLE
registered new plugin aiida-environ

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -479,5 +479,12 @@
         "plugin_info": "https://raw.github.com/lsmo-epfl/aiida-lsmo/master/setup.json",
         "code_home": "https://github.com/lsmo-epfl/aiida-lsmo",
         "pip_url": "git+https://github.com/lsmo-epfl/aiida-lsmo"
+    },
+    "aiida-environ": {
+        "entry_point_prefix": "environ",
+        "development_status": "beta",
+        "plugin_info": "https://raw.github.com/environ-developers/aiida-environ/master/setup.json",
+        "code_home": "https://github.com/environ-developers/aiida-environ",
+        "pip_url": "git+https://github.com/environ-developers/aiida-environ"
     }
 }


### PR DESCRIPTION
Hi aiidateam, I'd like to register aiida-environ as a plugin (note that the goal of this is to provide continued support for [Environ](https://github.com/environ-developers/Environ), which used to be a part of Quantum Espresso, and as a result, there is existing support for an older version of Environ currently in aiida-quantumespresso). 

Thanks!