### PR TITLE
chore: deprecate `development_status` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,6 @@ Use this to point to a Python module that contains a `__version__` variable with
 Useful for `flit` and `setuptools` configuration files that use the programmatic `version = attr: aiida_plugin.__version__` format.
 #### development_status (deprecated)
 The development status of a plugin used to be recorded explicitly on the plugin registry.
-Over time, we've moved closer and closer to adopting the [development status trove classifer](https://pypi.org/classifiers/), so we now suggest to just use those in your `setup.json`/`setup.cfg`/... file in your plugin.
+Over time, we've moved closer and closer to adopting the [development status trove classifer](https://pypi.org/classifiers/), so we now suggest to just use those in your `setup.json`/`setup.cfg`/... file of your plugin.
+
+If no development status is specified, the status will default to 'planning'.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ community of your ongoing work.
     },
     "aiida-new": {
         "entry_point_prefix": "new",
-        "development_status": "planning",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-new/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-new",
         "documentation_url": "http://aiida-new.readthedocs.io/"
@@ -48,13 +47,6 @@ By convention, a plugin `aiida-xxx` should use `"entry_point_prefix": "xxx"`.
 
 Example: `aiida-quantumespresso` uses the entry point prefix `quantumespresso` and provides numerous entry points, all of which start with `quantumespresso.`.
 
-#### development_status (required)
-The development status of your plugin, expressed using a [development status trove classifer](https://pypi.org/classifiers/), including:
-* `planning`: plugin is not yet in a working state. Use this to secure a specific name before starting development
-* `beta`: plugin adds new functionality but isn't stable enough for production use
-* `stable`: plugin can be used in production
-* `inactive`: plugin no longer maintained
-
 #### code_home (required)
 The link to the homepage of the plugin, for example its github repository.
 
@@ -72,3 +64,11 @@ For an example, see the [`setup.json`](https://github.com/aiidateam/aiida-diff/b
 
 #### documentation_url (optional)
 The link to the online documentation for your plugin, for example on readthedocs.org .
+
+#### version_file (optional)
+
+Use this to point to a Python module that contains a `__version__` variable with the version of your plugin.
+Useful for `flit` and `setuptools` configuration files that use the programmatic `version = attr: aiida_plugin.__version__` format.
+#### development_status (deprecated)
+The development status of a plugin used to be recorded explicitly on the plugin registry.
+Over time, we've moved closer and closer to adopting the [development status trove classifer](https://pypi.org/classifiers/), so we now suggest to just use those in your `setup.json`/`setup.cfg`/... file in your plugin.

--- a/aiida_registry/fetch_metadata.py
+++ b/aiida_registry/fetch_metadata.py
@@ -378,6 +378,7 @@ def validate_dev_status(plugin_data: dict):
     if plugin_data['metadata'] and 'Framework :: AiiDA' not in classifiers:
         report("  > WARNING: Missing classifier 'Framework :: AiiDA'")
 
+    # Read development status from plugin repo
     development_status = None
     for classifier in classifiers:
         if classifier in classifier_to_status:
@@ -395,12 +396,15 @@ def validate_dev_status(plugin_data: dict):
         )
 
     # prioritise development_status from plugins.json
-    if 'development_status' not in plugin_data:
-        plugin_data['development_status'] = development_status
+    if 'development_status' in plugin_data:
+        report('  > WARNING: `development_status` key is deprecated. '
+               'Use PyPI Trove classifiers in the plugin repository instead.')
+    else:
+        plugin_data['development_status'] = development_status or 'planning'
 
     # note: for more validation, it might be sensible to switch to voluptuous
     if plugin_data['development_status'] not in list(status_dict.keys()):
-        report("  > WARNING: Invalid state '{}'".format(
+        report("  > WARNING: Invalid development status '{}'".format(
             plugin_data['development_status']))
 
 

--- a/plugins.json
+++ b/plugins.json
@@ -10,7 +10,6 @@
     },
     "aiida-quantumespresso": {
         "entry_point_prefix": "quantumespresso",
-        "development_status": "stable",
         "pip_url": "aiida-quantumespresso",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-quantumespresso/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-quantumespresso",
@@ -25,14 +24,12 @@
     },
     "aiida-pseudo": {
         "entry_point_prefix": "pseudo",
-        "development_status": "beta",
         "pip_url": "aiida-pseudo",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-pseudo/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-pseudo"
     },
     "aiida-wannier90": {
         "entry_point_prefix": "wannier90",
-        "development_status": "stable",
         "pip_url": "aiida-wannier90",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-wannier90/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-wannier90",
@@ -48,7 +45,6 @@
     },
     "aiida-vasp": {
         "entry_point_prefix": "vasp",
-        "development_status": "beta",
         "pip_url": "aiida-vasp",
         "code_home": "https://github.com/aiida-vasp/aiida-vasp",
         "plugin_info": "https://raw.githubusercontent.com/aiida-vasp/aiida-vasp/master/setup.json",
@@ -63,7 +59,6 @@
     },
     "aiida-cp2k": {
         "entry_point_prefix": "cp2k",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/cp2k/aiida-cp2k/master/setup.json",
         "code_home": "https://github.com/cp2k/aiida-cp2k",
         "pip_url": "aiida-cp2k"
@@ -77,7 +72,6 @@
     },
     "aiida-quantumespresso-hp": {
         "entry_point_prefix": "quantumespresso.hp",
-        "development_status": "beta",
         "plugin_info": "https://raw.githubusercontent.com/sphuber/aiida-quantumespresso-hp/master/setup.json",
         "code_home": "https://github.com/sphuber/aiida-quantumespresso-hp",
         "pip_url": "git+https://github.com/sphuber/aiida-quantumespresso-hp"
@@ -92,7 +86,6 @@
     },
     "aiida-siesta": {
         "entry_point_prefix": "siesta",
-        "development_status": "stable",
         "pip_url": "aiida-siesta",
         "plugin_info": "https://raw.github.com/siesta-project/aiida_siesta_plugin/master/setup.json",
         "code_home": "https://github.com/siesta-project/aiida_siesta_plugin/tree/master",
@@ -107,7 +100,6 @@
     },
     "aiida-ase": {
         "entry_point_prefix": "ase",
-        "development_status": "stable",
         "pip_url": "aiida-ase",
         "plugin_info": "https://raw.github.com/aiidateam/aiida-ase/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-ase",
@@ -115,7 +107,6 @@
     },
     "aiida-codtools": {
         "entry_point_prefix": "codtools",
-        "development_status": "stable",
         "pip_url": "aiida-codtools",
         "plugin_info": "https://raw.githubusercontent.com/aiidateam/aiida-codtools/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-codtools",
@@ -123,7 +114,6 @@
     },
     "aiida-nwchem": {
         "entry_point_prefix": "nwchem",
-        "development_status": "stable",
         "pip_url": "aiida-nwchem",
         "plugin_info": "https://raw.githubusercontent.com/aiidateam/aiida-nwchem/master/setup.json",
         "code_home": "https://github.com/aiidateam/aiida-nwchem",
@@ -131,7 +121,6 @@
     },
     "aiida-phonopy": {
         "entry_point_prefix": "phonopy",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/aiida-phonopy/aiida-phonopy/master/setup.json",
         "code_home": "https://github.com/aiida-phonopy/aiida-phonopy",
         "pip_url": "aiida-phonopy",
@@ -154,7 +143,6 @@
     },
     "aiida-raspa": {
         "entry_point_prefix": "raspa",
-        "development_status": "stable",
         "plugin_info": "https://raw.github.com/yakutovicha/aiida-raspa/master/setup.json",
         "code_home": "https://github.com/yakutovicha/aiida-raspa",
         "pip_url": "aiida-raspa"
@@ -175,7 +163,6 @@
     },
     "aiida-phtools": {
         "entry_point_prefix": "phtools",
-        "development_status": "beta",
         "plugin_info": "https://raw.github.com/ltalirz/aiida-phtools/master/setup.json",
         "code_home": "https://github.com/ltalirz/aiida-phtools",
         "pip_url": "aiida-phtools"
@@ -190,7 +177,6 @@
     },
     "aiida-gollum": {
         "entry_point_prefix": "gollum",
-        "development_status": "beta",
         "plugin_info": "https://raw.github.com/garsua/aiida-gollum/master/setup.json",
         "code_home": "https://github.com/garsua/aiida-gollum/",
         "documentation_url": "https://aiida-gollum.readthedocs.io/",
@@ -198,7 +184,6 @@
     },
     "aiida-ddec": {
         "entry_point_prefix": "ddec",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/yakutovicha/aiida-ddec/master/setup.json",
         "code_home": "https://github.com/yakutovicha/aiida-ddec",
         "pip_url": "git+https://github.com/yakutovicha/aiida-ddec"
@@ -213,7 +198,6 @@
     },
     "aiida-crystal-dft": {
         "entry_point_prefix": "crystal_dft",
-        "development_status": "beta",
         "plugin_info": "https://raw.githubusercontent.com/tilde-lab/aiida-crystal-dft/master/setup.json",
         "documentation_url": "https://github.com/tilde-lab/aiida-crystal-dft",
         "code_home": "https://github.com/tilde-lab/aiida-crystal-dft",
@@ -221,14 +205,12 @@
     },
     "aiida-z2pack": {
         "entry_point_prefix": "z2pack",
-        "development_status": "beta",
         "plugin_info": "https://raw.githubusercontent.com/antimomarrazzo/aiida-z2pack/master/setup.json",
         "code_home": "https://github.com/AntimoMarrazzo/aiida-z2pack",
         "pip_url": "git+https://github.com/AntimoMarrazzo/aiida-z2pack"
     },
     "aiida-spex": {
         "entry_point_prefix": "spex",
-        "development_status": "planning",
         "code_home": "https://github.com/JuDFTteam/aiida-spex",
         "plugin_info": "https://raw.githubusercontent.com/JuDFTteam/aiida-spex/master/setup.json",
         "pip_url": "git+https://github.com/JuDFTteam/aiida-spex"
@@ -242,7 +224,6 @@
     },
     "aiida-optimize": {
         "entry_point_prefix": "optimize",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/greschd/aiida-optimize/master/setup.json",
         "code_home": "https://github.com/greschd/aiida-optimize",
         "documentation_url": "https://aiida-optimize.readthedocs.io",
@@ -250,7 +231,6 @@
     },
     "aiida-bands-inspect": {
         "entry_point_prefix": "bands_inspect",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/greschd/aiida-bands-inspect/master/setup.json",
         "code_home": "https://github.com/greschd/aiida-bands-inspect",
         "documentation_url": "https://aiida-bands-inspect.readthedocs.io",
@@ -258,7 +238,6 @@
     },
     "aiida-symmetry-representation": {
         "entry_point_prefix": "symmetry_representation",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/greschd/aiida_symmetry_representation/master/setup.json",
         "code_home": "https://github.com/greschd/aiida_symmetry_representation",
         "documentation_url": "https://aiida-symmetry-representation.readthedocs.io",
@@ -266,7 +245,6 @@
     },
     "aiida-strain": {
         "entry_point_prefix": "strain",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/greschd/aiida-strain/trunk/setup.json",
         "code_home": "https://github.com/greschd/aiida-strain",
         "documentation_url": "https://aiida-strain.readthedocs.io",
@@ -274,7 +252,6 @@
     },
     "aiida-tbmodels": {
         "entry_point_prefix": "tbmodels",
-        "development_status": "stable",
         "plugin_info": "https://raw.githubusercontent.com/greschd/aiida-tbmodels/master/setup.json",
         "code_home": "https://github.com/greschd/aiida-tbmodels",
         "documentation_url": "https://aiida-tbmodels.readthedocs.io",
@@ -282,7 +259,6 @@
     },
     "aiida-tbextraction": {
         "entry_point_prefix": "tbextraction",
-        "development_status": "beta",
         "plugin_info": "https://raw.githubusercontent.com/greschd/aiida-tbextraction/master/setup.json",
         "code_home": "https://github.com/greschd/aiida-tbextraction",
         "documentation_url": "https://aiida-tbextraction.readthedocs.io/",
@@ -297,7 +273,6 @@
     },
     "aiida-gaussian-datatypes": {
         "entry_point_prefix": "gaussian",
-        "development_status": "beta",
         "pip_url": "aiida-gaussian-datatypes",
         "plugin_info": "https://raw.github.com/dev-zero/aiida-gaussian-datatypes/master/setup.json",
         "code_home": "https://github.com/dev-zero/aiida-gaussian-datatypes",
@@ -305,7 +280,6 @@
     },
     "aiida-uppasd": {
         "entry_point_prefix": "uppasd",
-        "development_status": "planning",
         "pip_url": "git+https://github.com/unkcpz/aiida-uppasd",
         "plugin_info": "https://raw.github.com/uppasd/aiida-uppasd/master/setup.json",
         "code_home": "https://github.com/uppasd/aiida-uppasd",
@@ -327,14 +301,12 @@
     },
     "aiida-plumed": {
         "entry_point_prefix": "plumed",
-        "development_status": "beta",
         "code_home": "https://github.com/ConradJohnston/aiida-plumed",
         "plugin_info": "https://raw.github.com/ConradJohnston/aiida-plumed/AiiDA-v1.0-compatibility/setup.json",
         "pip_url": "aiida-plumed"
     },
     "aiida-graphql": {
         "entry_point_prefix": "graphql",
-        "development_status": "beta",
         "code_home": "https://github.com/dev-zero/aiida-graphql",
         "plugin_info": "https://raw.github.com/dev-zero/aiida-graphql/develop/pyproject.toml",
         "pip_url": "aiida-graphql"
@@ -393,7 +365,6 @@
     },
     "aiida-cusp": {
         "entry_point_prefix": "cusp",
-        "development_status": "beta",
         "plugin_info": "https://raw.githubusercontent.com/aiida-cusp/aiida-cusp/master/setup.json",
         "code_home": "https://github.com/aiida-cusp/aiida-cusp",
         "pip_url": "https://pypi.org/project/aiida-cusp",
@@ -408,7 +379,6 @@
     },
     "aiida-abinit": {
         "entry_point_prefix": "abinit",
-        "development_status": "beta",
         "pip_url": "aiida-abinit",
         "plugin_info": "https://raw.github.com/sponce24/aiida-abinit/master/setup.json",
         "code_home": "https://github.com/sponce24/aiida-abinit"
@@ -430,14 +400,12 @@
     },
     "aiida-catmap": {
         "entry_point_prefix": "catmap",
-        "development_status": "planning",
         "plugin_info": "https://raw.github.com/sudarshanv01/aiida-catmap/master/setup.json",
         "code_home": "https://github.com/sudarshanv01/aiida-catmap"
     },
     "aiida-spirit": {
         "name": "aiida-spirit",
         "entry_point_prefix": "spirit",
-        "development_status": "planning",
         "plugin_info": "https://raw.github.com/JuDFTteam/aiida-spirit/main/setup.json",
         "code_home": "https://github.com/JuDFTteam/aiida-spirit/tree/main",
         "documentation_url": "https://aiida-spirit.readthedocs.io/",
@@ -452,17 +420,14 @@
     },
     "aiida-eonclient": {
         "entry_point_prefix": "eonclient",
-        "development_status": "planning",
         "code_home": "https://github.com/HaoZeke/aiida-eonclient"
     },
     "aiida-eon": {
         "entry_point_prefix": "eon",
-        "development_status": "planning",
         "code_home": "https://github.com/HaoZeke/aiida-eon"
     },
     "aiida-wien2k": {
         "entry_point_prefix": "wien2k",
-        "development_status": "planning",
         "code_home": "https://github.com/rubel75/aiida-wien2k"
     },
     "aiida-supercell": {
@@ -482,7 +447,6 @@
     },
     "aiida-environ": {
         "entry_point_prefix": "environ",
-        "development_status": "beta",
         "plugin_info": "https://raw.github.com/environ-developers/aiida-environ/master/setup.json",
         "code_home": "https://github.com/environ-developers/aiida-environ",
         "pip_url": "git+https://github.com/environ-developers/aiida-environ"
@@ -504,7 +468,6 @@
     },
     "aiida-flexpart": {
         "entry_point_prefix": "flexpart",
-        "development_status": "planning",
         "plugin_info": "https://raw.githubusercontent.com/aiidaplugins/aiida-flexpart/main/setup.json",
         "code_home": "https://github.com/aiidaplugins/aiida-flexpart",
         "pip_url": "aiida-flexpart"


### PR DESCRIPTION
fix #191

Since the development status is now parsed from the various
configuration file formats in the plugin repository, duplicating this
information on the registry level leads to misalignment.

The information at the registry level can be dropped - for the moment,
we retain the key in cases where a corresponding trove classifier is not
yet present in the plugin repository (in order not to lose any
information).