### PR TITLE
fix: do not require pip url for alpha

### DIFF
--- a/aiida_registry/__init__.py
+++ b/aiida_registry/__init__.py
@@ -130,6 +130,8 @@ classifier_to_status = {
     'Development Status :: 7 - Inactive': 'inactive'
 }
 
+status_no_pip_url_allowed = {'planning', 'pre-alpha', 'alpha'}
+
 ## dictionary of human-readable entrypointtypes
 entrypointtypes = {k: v['longname'] for k, v in entrypoint_metainfo.items()}
 

--- a/aiida_registry/make_pages.py
+++ b/aiida_registry/make_pages.py
@@ -16,7 +16,8 @@ from collections import defaultdict
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 from . import (OTHERCOLORCLASS, PLUGINS_METADATA, entrypoint_metainfo,
-               entrypointtypes, main_entrypoints, status_dict)
+               entrypointtypes, main_entrypoints, status_dict,
+               status_no_pip_url_allowed)
 
 # Subfolders
 OUT_FOLDER = 'out'
@@ -139,7 +140,7 @@ def global_summary():
 def get_pip_install_cmd(plugin_data):
 
     if 'pip_url' not in plugin_data and plugin_data[
-            'development_status'] == 'planning':
+            'development_status'] in status_no_pip_url_allowed:
         return 'See source code repository.'
 
     pip_url = plugin_data['pip_url']

--- a/tests/static/plugins.yaml
+++ b/tests/static/plugins.yaml
@@ -1360,7 +1360,7 @@ graphql:
 gudhi:
   aiida_version: '>=0.11'
   code_home: https://github.com/ltalirz/aiida-gudhi
-  development_status: beta
+  development_status: alpha
   entry_point: gudhi
   entry_points:
     aiida.calculations:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -86,3 +86,6 @@ def test_pip_install_cmd():
 
     # aiida-core is stable version
     assert '--pre' not in get_pip_install_cmd(test_data['core'])
+
+    # aiida-gudhi is in alpha and does not provide a pip_url
+    assert 'See' not in get_pip_install_cmd(test_data['gudhi'])


### PR DESCRIPTION
Contrary to what was described in the README, the implementation choked
when plugins in alpha status were not providing a `pip_url`.