### PR TITLE
feat: extract info on calculations/workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,14 @@ jobs:
       run: pip install -e . -v
     - name: fetch metadata
       run: aiida-registry fetch
+
+    # See https://github.com/geerlingguy/raspberry-pi-dramble/issues/166
+    - name: Force GitHub Actions' docker daemon to use vfs.
+      run: |
+        sudo systemctl stop docker
+        echo '{"cgroup-parent":"/actions_job","storage-driver":"vfs"}' | sudo tee /etc/docker/daemon.json
+        sudo systemctl start docker
+
     - name: Try installing packages
       run: aiida-registry test-install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
         python-version: [3.8]
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 55
 
     steps:
     - uses: actions/checkout@v2

--- a/aiida_registry/__init__.py
+++ b/aiida_registry/__init__.py
@@ -16,6 +16,7 @@ pwd = os.path.split(os.path.abspath(__file__))[0]
 PLUGINS_FILE_ABS = os.path.join(pwd, os.pardir, 'plugins.yaml')
 PLUGINS_METADATA = 'plugins_metadata.json'
 PLUGINS_METADATA_KEYS = ['author', 'author_email', 'version', 'description']
+PLUGINS_TEST_RESULTS = 'test_results.json'
 
 # These are the main entrypoints, the other will fall under 'other'
 main_entrypoints = [

--- a/aiida_registry/fetch_metadata.py
+++ b/aiida_registry/fetch_metadata.py
@@ -4,6 +4,7 @@
 Data is primarily sourced from PyPI,
 with a fallback to the repository build file (setup.json, setup.cfg, pyproject.toml).
 """
+# pylint: disable=consider-using-f-string
 import json
 import os
 import re
@@ -27,8 +28,9 @@ def get_hosted_on(url):
     """Get the hosting service from a URL."""
     try:
         requests.get(url, timeout=30)
-    except Exception:
-        raise ValueError("Unable to open 'code_home' url: '{}'".format(url))
+    except Exception as exc:
+        raise ValueError(
+            "Unable to open 'code_home' url: '{}'".format(url)) from exc
 
     netloc = urllib.parse.urlparse(url).netloc
 
@@ -216,7 +218,7 @@ def is_pip_url_pypi(string: str) -> bool:
 
 def fetch_metadata(filter_list=None, fetch_pypi=True, fetch_pypi_wheel=True):
     """Fetch metadata from PyPI and AiiDA-Plugins."""
-    with open(PLUGINS_FILE_ABS) as handle:
+    with open(PLUGINS_FILE_ABS, encoding='utf8') as handle:
         plugins_raw_data: dict = yaml.safe_load(handle)
 
     plugins_metadata = OrderedDict()
@@ -231,7 +233,7 @@ def fetch_metadata(filter_list=None, fetch_pypi=True, fetch_pypi_wheel=True):
             fetch_pypi=fetch_pypi,
             fetch_pypi_wheel=fetch_pypi_wheel)
 
-    with open(PLUGINS_METADATA, 'w') as handle:
+    with open(PLUGINS_METADATA, 'w', encoding='utf8') as handle:
         json.dump(plugins_metadata, handle, indent=2, sort_keys=True)
     REPORTER.info(f'{PLUGINS_METADATA} dumped')
 

--- a/aiida_registry/make_pages.py
+++ b/aiida_registry/make_pages.py
@@ -3,7 +3,7 @@
 
 Reads plugin-metadata.json produced by fetch_metadata.
 """
-# pylint: disable=missing-function-docstring,invalid-name,global-statement
+# pylint: disable=missing-function-docstring,invalid-name,global-statement,consider-using-f-string
 
 import codecs
 import copy
@@ -43,9 +43,9 @@ def get_html_plugin_fname(plugin_name):
 
 def get_summary_info(entry_points):
     """Get info for plugin detail page.
-    """
-    global entrypoints_count, other_entrypoint_names
 
+    Note: this updates the global variables entrypoints_count and other_entrypoint_names.
+    """
     summary_info = []
     ep = (entry_points or {}).copy()
 
@@ -111,8 +111,6 @@ def format_entry_points_list(ep_list):
 
 def global_summary():
     """Compute summary of plugin registry."""
-    global entrypoints_count, other_entrypoint_names
-
     summary = []
     for entrypoint_name in main_entrypoints:
         summary.append({
@@ -152,7 +150,7 @@ def get_pip_install_cmd(plugin_data):
     try:
         version = plugin_data['metadata']['version']
         pre_releases = ['a', 'b', 'rc']
-        if any([version.find(p_id) != -1 for p_id in pre_releases]):
+        if any(version.find(p_id) != -1 for p_id in pre_releases):
             return 'pip install --pre {}'.format(pip_url)
         return 'pip install {}'.format(pip_url)
     except (KeyError, TypeError):
@@ -173,7 +171,7 @@ def make_pages():
         autoescape=select_autoescape(['html', 'xml']),
     )
 
-    with open(PLUGINS_METADATA) as f:
+    with open(PLUGINS_METADATA, encoding='utf8') as f:
         plugins_metadata = json.load(f)
 
     # Create HTML view for each plugin

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -1,22 +1,29 @@
 # -*- coding: utf-8 -*-
-"""Test installing all registered plugins."""
-# pylint: disable=missing-function-docstring
+"""Test installing registered plugins.
+
+This uses the aiida-core Docker container to test the installation of the plugins.
+"""
+# pylint: disable=missing-function-docstring,consider-using-f-string,too-few-public-methods
 
 import json
-import subprocess
+import os
 import sys
 
-from . import PLUGINS_METADATA
+import attrs
+
+from . import PLUGINS_METADATA, PLUGINS_TEST_RESULTS
+
+# Where to mount the workdir inside the Docker container
+_DOCKER_WORKDIR = '/tmp/scripts'
 
 
-def try_cmd(cmd):
-    try:
-        return subprocess.check_output(cmd,
-                                       shell=True,
-                                       stderr=subprocess.STDOUT)
-    except subprocess.CalledProcessError as exc:
-        print(exc.output)
-        return False
+@attrs.define
+class TestResult:
+    """Test result."""
+    is_installable: bool
+    is_importable: bool
+    process_metadata: dict
+    error_message: str
 
 
 def has_python_version_classifier(plugin_info):
@@ -52,46 +59,120 @@ def supports_python_version(plugin_info):
     return False
 
 
-def test_install():
-    with open(PLUGINS_METADATA, 'r') as handle:
+def handle_error(process_result, message):
+    error_message = ''
+
+    if process_result.exit_code != 0:
+        error_message = process_result.output.decode('utf8')
+        raise ValueError(f'{message}\n{error_message}')
+
+    return error_message
+
+
+def test_install_one_docker(container_image, plugin):
+    """Test installing one plugin in a Docker container."""
+    import docker  # pylint: disable=import-outside-toplevel
+    client = docker.from_env()
+
+    is_package_installed = False
+    is_package_importable = False
+    process_metadata = {}
+    error_message = ''
+
+    print('   - Starting container for {}'.format(plugin['name']))
+    container = client.containers.run(
+        container_image,
+        detach=True,
+        volumes={os.getcwd(): {
+                     'bind': _DOCKER_WORKDIR,
+                     'mode': 'rw'
+                 }},
+    )
+
+    try:
+
+        print('   - Installing plugin {}'.format(plugin['name']))
+        install_package = container.exec_run(
+            f'pip install --pre {plugin["pip_url"]}')
+
+        error_message = handle_error(
+            install_package, f"Failed to install plugin {plugin['name']}")
+
+        # Should make this depend on the AiiDA version inside the container,
+        # at least after 2.0 is out that removes reentry
+        _reentry_scan = container.exec_run('reentry scan -r aiida')
+
+        is_package_installed = True
+
+        if 'package_name' not in list(plugin.keys()):
+            plugin['package_name'] = plugin['name'].replace('-', '_')
+
+        print('   - Importing {}'.format(plugin['package_name']))
+        import_package = container.exec_run("python -c 'import {}'".format(
+            plugin['package_name']))
+
+        error_message = handle_error(
+            import_package,
+            f"Failed to import package {plugin['package_name']}")
+        is_package_importable = True
+
+        extract_metadata = container.exec_run(
+            workdir=_DOCKER_WORKDIR,
+            cmd='python ./bin/analyze_entrypoints.py -o result.json')
+        error_message = handle_error(
+            extract_metadata,
+            f"Failed to fetch entry point metadata for package {plugin['package_name']}"
+        )
+
+        with open('result.json', 'r', encoding='utf8') as handle:
+            process_metadata = json.load(handle)
+
+    except ValueError as exc:
+        print(f'   >> ERROR: {str(exc)}')
+
+    finally:
+        container.remove(force=True)
+
+    return attrs.asdict(
+        TestResult(is_installable=is_package_installed,
+                   is_importable=is_package_importable,
+                   process_metadata=process_metadata,
+                   error_message=error_message))
+
+
+def test_install_all(container_image):
+    with open(PLUGINS_METADATA, 'r', encoding='utf8') as handle:
         data = json.load(handle)
 
+    test_results = []
+
     print('[test installing plugins]')
-    for _k, val in data.items():
+    for _k, plugin in data.items():
 
-        print(' - {}'.format(val['name']))
+        print(' - {}'.format(plugin['name']))
 
-        if not supports_python_version(val):
-            continue
+        # this currently checks for the wrong python version
+        #if not supports_python_version(plugin):
+        #    continue
 
         # 'planning' plugins aren't installed/tested
-        if val['development_status'] in ['planning', 'pre-alpha', 'alpha']:
+        if plugin['development_status'] in ['planning']:
+            print('    >> SKIPPING: plugin at planning state')
             continue
 
-        if 'pip_url' not in list(val.keys()):
-            print('    >> WARNING: Missing pip_url key!')
+        if 'pip_url' not in list(plugin.keys()):
+            if plugin['development_status'] not in [
+                    'planning', 'pre-alpha', 'alpha'
+            ]:
+                print(
+                    f"    >> WARNING: pip_url key missing, despite required for {plugin['development_status']} stage !"
+                )
+            else:
+                print('    >> SKIPPING: No pip_url key provided')
             continue
 
-        # Idea: create conda environment for each package to isolate installs...
-        # print("   - Creating environment for {}".format(val['name']))
-        # py_version = "{}.{}".format(sys.version_info[0], sys.version_info[1])
-        # is_env_installed = try_cmd("conda create -n {} python={} -y && conda activate"\
-        #       .format(val['name'], py_version))
-        # if not is_env_installed:
-        #     continue
+        test_results.append(test_install_one_docker(container_image, plugin))
 
-        print('   - Installing {}'.format(val['name']))
-        is_package_installed = try_cmd('pip install --pre {}'.format(
-            val['pip_url']))
-
-        if not is_package_installed:
-            continue
-
-        if 'package_name' not in list(val.keys()):
-            val['package_name'] = val['name'].replace('-', '_')
-
-        print('   - Importing {}'.format(val['package_name']))
-        try_cmd("python -c 'import {}'".format(val['package_name']))
-
-        # print("   - Removing environment for {}".format(val['name']))
-        # is_env_removed = try_cmd("conda env remove -n {}".format(val['name']))
+    print(f'Dumping {PLUGINS_TEST_RESULTS}')
+    with (open(PLUGINS_TEST_RESULTS, 'w', encoding='utf8')) as handle:
+        json.dump(test_results, handle, indent=2)

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -8,8 +8,7 @@ This uses the aiida-core Docker container to test the installation of the plugin
 import json
 import os
 import sys
-
-import attrs
+from dataclasses import asdict, dataclass
 
 from . import PLUGINS_METADATA, PLUGINS_TEST_RESULTS
 
@@ -17,7 +16,7 @@ from . import PLUGINS_METADATA, PLUGINS_TEST_RESULTS
 _DOCKER_WORKDIR = '/tmp/scripts'
 
 
-@attrs.define
+@dataclass
 class TestResult:
     """Test result."""
     is_installable: bool
@@ -133,7 +132,7 @@ def test_install_one_docker(container_image, plugin):
     finally:
         container.remove(force=True)
 
-    return attrs.asdict(
+    return asdict(
         TestResult(is_installable=is_package_installed,
                    is_importable=is_package_importable,
                    process_metadata=process_metadata,

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -71,7 +71,7 @@ def handle_error(process_result, message):
 def test_install_one_docker(container_image, plugin):
     """Test installing one plugin in a Docker container."""
     import docker  # pylint: disable=import-outside-toplevel
-    client = docker.from_env()
+    client = docker.from_env(timeout=180)
 
     is_package_installed = False
     is_package_importable = False
@@ -115,6 +115,8 @@ def test_install_one_docker(container_image, plugin):
             f"Failed to import package {plugin['package_name']}")
         is_package_importable = True
 
+        print('   - Extracting entry point metadata for {}'.format(
+            plugin['package_name']))
         extract_metadata = container.exec_run(
             workdir=_DOCKER_WORKDIR,
             cmd='python ./bin/analyze_entrypoints.py -o result.json')

--- a/bin/aiida-registry
+++ b/bin/aiida-registry
@@ -19,9 +19,10 @@ def html():
     make_pages()
 
 @cli.command()
-def test_install():
-    from aiida_registry.test_install import test_install
-    test_install()
+@click.option('--container-image', default='aiidateam/aiida-core:latest', help='Container image to use for the install')
+def test_install(container_image):
+    from aiida_registry.test_install import test_install_all
+    test_install_all(container_image)
 
 
 if __name__ == '__main__':

--- a/bin/analyze_entrypoints.py
+++ b/bin/analyze_entrypoints.py
@@ -6,14 +6,13 @@ Adapted from `aiida.cmdline.commands.cmd_plugin`.
 
 Note: This script should run inside the aiida-core docker container without requiring additional dependencies.
 """
-# pylint: disable=missing-class-docstring
+# pylint: disable=missing-class-docstring,import-outside-toplevel
 import inspect
 import json
 from dataclasses import asdict, dataclass
 from typing import Dict, List
 
 import click
-from aiida.plugins.entry_point import get_entry_point_names
 
 ENTRY_POINT_GROUPS = [
     'aiida.calculations',
@@ -54,6 +53,8 @@ def document_entry_point_group(entry_point_group) -> Dict[str, ProcessInfo]:
     :param entry_point_group: the entry point group
     :return: a dictionary with the entry point name as key and the entry point metadata as value
     """
+    from aiida.plugins.entry_point import \
+        get_entry_point_names  # pylint: disable=import-error
     entry_points = get_entry_point_names(entry_point_group)
 
     if not entry_points:
@@ -75,7 +76,7 @@ def document_entry_point(entry_point_group: str,
     :param entry_point_group: the entry point group
     :param entry_point: the entry point name
     """
-    # pylint: disable=import-outside-toplevel
+    # pylint: disable=import-outside-toplevel,import-error
     from aiida.common import EntryPointError
     from aiida.engine import Process
     from aiida.plugins.entry_point import load_entry_point

--- a/bin/analyze_entrypoints.py
+++ b/bin/analyze_entrypoints.py
@@ -1,0 +1,177 @@
+# -*- coding: utf-8 -*-
+""""
+Fetch information about plugins and print it in a human-readable format.
+
+Adapted from `aiida.cmdline.commands.cmd_plugin`.
+
+Note: This script should run inside the aiida-core docker container without requiring additional dependencies.
+"""
+# pylint: disable=missing-class-docstring
+import inspect
+import json
+from dataclasses import asdict, dataclass
+from typing import Dict, List
+
+import click
+from aiida.plugins.entry_point import get_entry_point_names
+
+ENTRY_POINT_GROUPS = [
+    'aiida.calculations',
+    'aiida.workflows',
+]
+
+
+@dataclass
+class ProcessSpecEntry:
+    name: str
+    required: bool
+    valid_types: list
+    info: str
+
+
+@dataclass
+class ExitCode:
+    status: str
+    message: int
+
+
+@dataclass
+class ProcessSpec:
+    inputs: List[ProcessSpecEntry]
+    outputs: List[ProcessSpecEntry]
+    exit_codes: List[ExitCode]
+
+
+@dataclass
+class ProcessInfo:
+    description: str
+    spec: ProcessSpec
+
+
+def document_entry_point_group(entry_point_group) -> Dict[str, ProcessInfo]:
+    """Extract metadata for each entry point in a group.
+
+    :param entry_point_group: the entry point group
+    :return: a dictionary with the entry point name as key and the entry point metadata as value
+    """
+    entry_points = get_entry_point_names(entry_point_group)
+
+    if not entry_points:
+        return {}
+
+    groups_dict = {}
+    for entry_point in entry_points:
+        process_info = document_entry_point(entry_point_group, entry_point)
+        if process_info is not None:
+            groups_dict[entry_point] = asdict(process_info)
+
+    return groups_dict
+
+
+def document_entry_point(entry_point_group: str,
+                         entry_point: str) -> ProcessInfo:
+    """Extract metadata for an entry point.
+
+    :param entry_point_group: the entry point group
+    :param entry_point: the entry point name
+    """
+    # pylint: disable=import-outside-toplevel
+    from aiida.common import EntryPointError
+    from aiida.engine import Process
+    from aiida.plugins.entry_point import load_entry_point
+
+    try:
+        plugin = load_entry_point(entry_point_group, entry_point)
+    except EntryPointError as exception:
+        print(str(exception))
+    else:
+        if (inspect.isclass(plugin)
+                and issubclass(plugin, Process)) or plugin.is_process_function:
+            return document_process_info(plugin)
+        print(f'Error: {plugin} is not a Process.')
+
+    return None
+
+
+def document_process_info(process):
+    """Print detailed information about a process class and its process specification.
+
+    :param process: a :py:class:`~aiida.engine.processes.process.Process` class
+    """
+    docstring = process.__doc__
+
+    if docstring is not None:
+        docstring = docstring.strip().split('\n')
+
+    if not docstring:
+        docstring = ['No description available']
+
+    return ProcessInfo(spec=document_process_spec(process.spec()),
+                       description=docstring)
+
+
+def document_process_spec(process_spec):
+    """Get the process spec in a human-readable formatted way.
+
+    :param process_spec: a `ProcessSpec` instance
+    """
+    def build_entries(ports) -> List[ProcessSpecEntry]:
+        """Build a list of entries to be printed for a `PortNamespace.
+
+        :param ports: the port namespace
+        :return: list of tuples with port name, required, valid types and info strings
+        """
+        result = []
+
+        for name, port in sorted(ports.items(),
+                                 key=lambda x: (not x[1].required, x[0])):
+
+            if name.startswith('_'):
+                continue
+
+            valid_types = port.valid_type if isinstance(
+                port.valid_type, (list, tuple)) else (port.valid_type, )
+            valid_types = ', '.join([
+                valid_type.__name__ for valid_type in valid_types
+                if valid_type is not None
+            ])
+            required = port.required
+            info = port.help if port.help is not None else ''
+            info = f'{info[:75]} ...' if len(info) > 75 else info
+            result.append(
+                ProcessSpecEntry(name=name,
+                                 required=required,
+                                 valid_types=valid_types,
+                                 info=info))
+
+        return result
+
+    inputs = build_entries(process_spec.inputs)
+    outputs = build_entries(process_spec.outputs)
+
+    exit_codes = []
+    for exit_code in sorted(process_spec.exit_codes.values(),
+                            key=lambda exit_code: exit_code.status):
+        message = exit_code.message
+        exit_codes.append(ExitCode(status=exit_code.status, message=message))
+
+    return ProcessSpec(inputs=inputs, outputs=outputs, exit_codes=exit_codes)
+
+
+@click.command()
+@click.option('--output', '-o', type=str, default=None, help='Output file')
+def cli(output):
+    """Fetch information about plugins and print it in a human-readable format."""
+    result = {}
+    for ep_group in ENTRY_POINT_GROUPS:
+        result[ep_group] = document_entry_point_group(ep_group)
+
+    if output is None:
+        print(result)
+    else:
+        with open(output, 'w', encoding='utf8') as handle:
+            json.dump(result, handle, indent=4)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -13,7 +13,7 @@ aiida-alloy:
   code_home: https://github.com/DanielMarchand/aiida-alloy
   development_status: beta
   entry_point_prefix: alloy
-  pip_url: git+https://github.com/aiidateam/aiida-alloy
+  pip_url: git+https://github.com/DanielMarchand/aiida-alloy
   plugin_info: https://raw.githubusercontent.com/DanielMarchand/aiida-alloy/master/setup.json
 aiida-ase:
   code_home: https://github.com/aiidateam/aiida-ase
@@ -140,7 +140,7 @@ aiida-fireworks-scheduler:
   development_status: beta
   documentation_url: https://aiida-fireworks-scheduler.readthedocs.io
   entry_point_prefix: fireworks_scheduler
-  pip_url: git+https://https://github.com/zhubonan/aiida-fireworks-scheduler
+  pip_url: git+https://github.com/zhubonan/aiida-fireworks-scheduler
   plugin_info: https://raw.github.com/zhubonan/aiida-fireworks-scheduler/master/setup.json
 aiida-fleur:
   code_home: https://github.com/JuDFTteam/aiida-fleur/tree/develop

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ if __name__ == '__main__':
     setup(
         name='aiida-registry',
         packages=find_packages(),
-        long_description=open('README.md').read(),
+        long_description=open('README.md', encoding='utf8').read(),  # pylint: disable=consider-using-with
         long_description_content_type='text/markdown',
-        version='0.2.0',
+        version='0.3.0',
         description='Registry of AiiDA plugins.',
         author='AiiDA Team',
         author_email='aiidateam@gmail.com',
@@ -26,6 +26,7 @@ if __name__ == '__main__':
             'tomlkit',
             'click~=7.1',
             'pyyaml~=6.0',
+            'docker~=5.0',
         ],
         license='MIT',
         extras_require={

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,14 @@ if __name__ == '__main__':
             'click~=7.1',
             'pyyaml~=6.0',
             'docker~=5.0',
+            # https://github.com/aws/aws-sam-cli/issues/3661
+            'markupsafe~=2.0.1'
         ],
         license='MIT',
         extras_require={
             'pre-commit': [
                 'pre-commit~=2.2',
-                'pylint~=2.5.0',
+                'pylint~=2.11.0',
             ],
             'testing': ['pytest', 'pytest-regressions'],
         },

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -65,7 +65,7 @@ def test_entrypoint_checks(capsys):
 
     The registry should check only entry points from the 'aiida.' groups.
     """
-    with open(TEST_PATH / 'plugins.yaml', 'r') as handle:
+    with open(TEST_PATH / 'plugins.yaml', 'r', encoding='utf8') as handle:
         test_data = yaml.safe_load(handle)
 
     # aiida-gulp example contains 'reaxff' entry point in 'gulp.potentials' group
@@ -78,7 +78,7 @@ def test_entrypoint_checks(capsys):
 
 def test_pip_install_cmd():
     """Test pip install command to display."""
-    with open(TEST_PATH / 'plugins.yaml', 'r') as handle:
+    with open(TEST_PATH / 'plugins.yaml', 'r', encoding='utf8') as handle:
         test_data = yaml.safe_load(handle)
 
     # aiida-crystal17 is beta version


### PR DESCRIPTION
For plugins that can be installed successfully, inspect the process
classes provided by them (similar to what `verdi plugin` does) and store
this information in a local json file.

This is in preparation of a more detailed information shown on
the registry.

Also:
 - Switch installation tests to aiida-core docker container in order to
   get a clean install every time.