### PR TITLE
Add `aiida-dataframe`

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -475,5 +475,6 @@ aiida-catmat:
   plugin_info: https://raw.githubusercontent.com/pzarabadip/aiida-catmat/develop/setup.json
 aiida-dataframe:
   entry_point_prefix: dataframe
-  plugin_info: https://raw.github.com/janssenhenning/aiida-dataframe/main/setup.json
+  plugin_info: https://raw.github.com/janssenhenning/aiida-dataframe/main/pyproject.toml
   code_home: https://github.com/janssenhenning/aiida-dataframe
+  version_file: https://raw.githubusercontent.com/janssenhenning/aiida-dataframe/main/aiida_dataframe/__init__.py

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -473,3 +473,7 @@ aiida-catmat:
   documentation_url: https://aiida-catmat.readthedocs.io/
   pip_url: aiida-catmat
   plugin_info: https://raw.githubusercontent.com/pzarabadip/aiida-catmat/develop/setup.json
+aiida-dataframe:
+  entry_point_prefix: dataframe
+  plugin_info: https://raw.github.com/janssenhenning/aiida-dataframe/main/setup.json
+  code_home: https://github.com/janssenhenning/aiida-dataframe


### PR DESCRIPTION
This PR adds `aiida-dataframe`, which contains a Data plugin for `pandas.DataFrame` objects (alpha)