### PR TITLE
Add aiida-python

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -296,6 +296,9 @@ aiida-psi4:
   entry_point_prefix: psi4
   pip_url: git+https://github.com/ltalirz/aiida-psi4
   plugin_info: https://raw.github.com/ltalirz/aiida-psi4/master/setup.json
+aiida-python:
+  entry_point_prefix: aiidapython
+  code_home: https://github.com/addman2/aiida-python
 aiida-qeq:
   code_home: https://github.com/ltalirz/aiida-qeq
   development_status: stable


### PR DESCRIPTION
For some time I was working on this plugin. It allows running python code as a *CalcJob*. One can create a new CalcJob inhereting class *CalcJobPython*, then overwrite method run_python and everything will be solved by the parent class it self and its corresponding parser so the developer of the derivated package does not have to write special parser. The executable of this derivated ClasJob should be some python instance with some environment.

For better view please look at the example/example.py file or example/example_diagonalization.py. More examples are coming. Even I already am using the package the development is still in alpha stage.