### PR TITLE
Sort plugins by the commits count.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
       run: pip install -e . -v
     - name: fetch metadata
       id: fetch_metadata
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
     - name: make pages
       run: aiida-registry html
@@ -67,6 +69,8 @@ jobs:
     - name: Install
       run: pip install -e . -v
     - name: fetch metadata
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
 
 #     # See https://github.com/geerlingguy/raspberry-pi-dramble/issues/166
@@ -97,4 +101,6 @@ jobs:
     - name: Install
       run: pip install -e .[testing] -v
     - name: Run tests
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: pytest tests/

--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -20,6 +20,8 @@ jobs:
       run: pip install -e . -v
     - name: fetch metadata
       id: fetch_metadata
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
     - name: Create commit comment
       if: steps.fetch_metadata.outputs.error

--- a/.github/workflows/webpage.yml
+++ b/.github/workflows/webpage.yml
@@ -32,6 +32,8 @@ jobs:
       run: pip install -e . -v
     - name: fetch metadata
       id: fetch_metadata
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
     - name: make pages
       run: aiida-registry html

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.sqlite
 out/
 plugins_metadata.json
+installed_plugins/

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
             scripts=["bin/aiida-registry"],
             install_requires=[
                 "jinja2~=2.11",
-                "requests~=2.24",
+                "requests~=2.28.1",
                 "requests-cache~=0.5.2",
                 "requirements-parser~=0.2.0",
                 "poetry~=1.1.15",


### PR DESCRIPTION
Used github API to get the commits endpoint. This endpoint provides information about each commit. To get the commits count in the last three months. We specify the period in the params of the request and then get the length of the response in this period. which is the commits count.

Get commits count for plugins not hosted on github. Used subprocess module to interact with Git.
First we clone the plugin and then retrieve the commits count in the past three months from it.

This PR needs a github access token to be a repository secret named `TOKEN