### PR TITLE
Display Entry points information & Add Sort feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,6 @@ jobs:
     - name: Install npm dependencies and build
       run: |
         npm install
-        export VITE_BASE_PATH="/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
         npm run build
       working-directory: ./aiida-registry-app
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
     - name: Install npm dependencies and build
       run: |
         npm install
-        export BASE_PATH="/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
+        export VITE_BASE_PATH="/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
         npm run build
       working-directory: ./aiida-registry-app
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
+    - name: Get entry points data
+      run: aiida-registry test-install
     - name: Move JSON file to the React project
       run: |
         mv plugins_metadata.json aiida-registry-app/src/
@@ -41,7 +43,7 @@ jobs:
     - name: Install npm dependencies and build
       run: |
         npm install
-        export BASE_PATH="/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
+        export VITE_BASE_PATH="/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
         npm run build
       working-directory: ./aiida-registry-app
     - name: Add plugins_metadata.json to the build folder

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Install npm dependencies and build
       run: |
         npm install
-        export VITE_BASE_PATH="/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
+        export VITE_PR_PREVIEW_PATH="/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
         npm run build
       working-directory: ./aiida-registry-app
     - name: Add plugins_metadata.json to the build folder

--- a/.github/workflows/webpage.yml
+++ b/.github/workflows/webpage.yml
@@ -35,6 +35,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
+    - name: Get entry points data
+      run: aiida-registry test-install
     - name: Commit json file
       run: |
         mv plugins_metadata.json aiida-registry-app/src/

--- a/aiida-registry-app/package.json
+++ b/aiida-registry-app/package.json
@@ -11,6 +11,10 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.0",
+    "@mui/material": "^5.14.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2"

--- a/aiida-registry-app/package.json
+++ b/aiida-registry-app/package.json
@@ -15,6 +15,7 @@
     "@emotion/styled": "^11.11.0",
     "@mui/icons-material": "^5.14.0",
     "@mui/material": "^5.14.0",
+    "markdown-to-jsx": "^7.2.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.11.2"

--- a/aiida-registry-app/src/App.css
+++ b/aiida-registry-app/src/App.css
@@ -47,7 +47,9 @@ a:hover {
 h1 {
   font-weight: bold;
 }
-
+.ep_description code {
+  background-color: #d5cccc;
+}
 
 .keyword {
   display: inline;

--- a/aiida-registry-app/src/App.jsx
+++ b/aiida-registry-app/src/App.jsx
@@ -23,7 +23,6 @@ const length = Object.keys(plugins).length;
 const currentPath = import.meta.env.VITE_BASE_PATH || "/aiida-registry/";
 
 function App() {
-  console.log(currentPath);
 
   return (
     <>
@@ -124,11 +123,12 @@ function MainIndex() {
 
       {Object.entries(sortedData).map(([key, value]) => (
         <div className='submenu-entry' key={key}>
-          <Link to={`/${key}`}><h2>{key}</h2></Link>
-          {value.is_installable === "true" ? (
-            <p>Installable</p>
-          ):(
-            <p>Can't be installed</p>
+          <Link to={`/${key}`}><h2 style={{display:'inline'}}>{key} </h2></Link>
+          {value.is_installable === "True" && (
+            <div className='classbox' style={{backgroundColor:'transparent'}}>
+            <p style={{color:'green', fontSize:'25px'}}>&#10003;</p>
+            <span className='tooltiptext'>Plugin successfully installed</span>
+            </div>
           )}
           <p className="currentstate">
           <img className="svg-badge" src= {`${currentPath}${status_dict[value.development_status][1]}`} title={status_dict[value.development_status][0]} />&nbsp;

--- a/aiida-registry-app/src/App.jsx
+++ b/aiida-registry-app/src/App.jsx
@@ -134,7 +134,13 @@ function MainIndex() {
                 src={`https://img.shields.io/badge/AiiDA-${value.aiida_version}-007ec6.svg?logo=${base64Icon}`}
               />
           )}
-
+          {sortOption === 'commits' &&
+          <img
+                className="svg-badge"
+                style={{padding:'3px'}}
+                src={`https://img.shields.io/badge/Yearly%20Commits-${value.commits_count}-007ec6.svg`}
+              />
+          }
           </p>
 
           <p>{value.metadata.description}</p>

--- a/aiida-registry-app/src/App.jsx
+++ b/aiida-registry-app/src/App.jsx
@@ -148,7 +148,7 @@ function MainIndex() {
             </li>
           )}
           <li>
-          <a href={`/${key}`}>Plugin details</a>
+          <Link to={`/${key}`}>Plugin details</Link>
           </li>
 
           </ul>

--- a/aiida-registry-app/src/App.jsx
+++ b/aiida-registry-app/src/App.jsx
@@ -125,6 +125,11 @@ function MainIndex() {
       {Object.entries(sortedData).map(([key, value]) => (
         <div className='submenu-entry' key={key}>
           <Link to={`/${key}`}><h2>{key}</h2></Link>
+          {value.is_installable === "true" ? (
+            <p>Installable</p>
+          ):(
+            <p>Can't be installed</p>
+          )}
           <p className="currentstate">
           <img className="svg-badge" src= {`${currentPath}${status_dict[value.development_status][1]}`} title={status_dict[value.development_status][0]} />&nbsp;
           {value.aiida_version && (

--- a/aiida-registry-app/src/App.jsx
+++ b/aiida-registry-app/src/App.jsx
@@ -13,14 +13,14 @@ import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select from '@mui/material/Select';
-
+import Markdown from 'markdown-to-jsx';
 
 const entrypointtypes = jsonData["entrypointtypes"]
 const globalsummary = jsonData["globalsummary"]
 const plugins  = jsonData["plugins"]
 const status_dict = jsonData["status_dict"]
 const length = Object.keys(plugins).length;
-const currentPath = import.meta.env.VITE_BASE_PATH || "/aiida-registry/";
+const currentPath = import.meta.env.VITE_PR_PREVIEW_PATH || "/aiida-registry/";
 
 function App() {
 
@@ -335,15 +335,18 @@ const EntryPoints = ({entryPoints}) => {
         </tr>
     </tbody>
 </table>
-
 <table>
-
-    <tr>
+<tr>
         <th>Description</th>
     </tr>
-    <tr>
-        <td colSpan={"4"}>{entryPoints.description}</td>
+      {entryPoints.description.map((description) => (
+    <tr className='ep_description'>
+        <Markdown>{description.trim()}</Markdown>
     </tr>
+      ))}
+</table>
+
+<table>
 
     <tr>
         <th>Inputs</th>
@@ -351,14 +354,7 @@ const EntryPoints = ({entryPoints}) => {
         <th>Valid Types</th>
         <th>Description</th>
     </tr>
-    {entryPoints.spec.inputs.map((inputs) => (
-      <tr>
-        <td>{inputs.name}</td>
-        <td>{inputs.required.toString()}</td>
-        <td>{inputs.valid_types}</td>
-        <td>{inputs.info}</td>
-      </tr>
-    ))}
+    <Specs spec={entryPoints.spec.inputs} />
 
     <tr>
         <th>Outputs</th>
@@ -367,14 +363,7 @@ const EntryPoints = ({entryPoints}) => {
         <th>Description</th>
     </tr>
 
-    {entryPoints.spec.outputs.map((outputs) => (
-      <tr>
-        <td>{outputs.name}</td>
-        <td>{outputs.required.toString()}</td>
-        <td>{outputs.valid_types}</td>
-        <td>{outputs.info}</td>
-      </tr>
-    ))}
+    <Specs spec={entryPoints.spec.outputs} />
 
 </table>
 <table>
@@ -387,9 +376,9 @@ const EntryPoints = ({entryPoints}) => {
         <th>Message</th>
     </tr>
     {entryPoints.spec.exit_codes.map((exit_codes) => (
-      <tr>
+      <tr className='ep_description'>
         <td>{exit_codes.status}</td>
-        <td>{exit_codes.message}</td>
+        <Markdown>{exit_codes.message}</Markdown>
       </tr>
     ))}
 
@@ -398,4 +387,19 @@ const EntryPoints = ({entryPoints}) => {
   );
 
 };
+const Specs = ({spec}) => {
+  return (
+    <>
+         {spec.map((inputs) => (
+           <tr className='ep_description'>
+          <td>{inputs.name}</td>
+          <td>{inputs.required.toString()}</td>
+          <td>{inputs.valid_types}</td>
+          <Markdown>{inputs.info}</Markdown>
+        </tr>
+      ))}
+    </>
+
+  )
+}
 export default App;

--- a/aiida-registry-app/src/App.jsx
+++ b/aiida-registry-app/src/App.jsx
@@ -62,7 +62,7 @@ function MainIndex() {
   const [sortedData, setSortedData] = useState(plugins);
   const handleSort = (option) => {
     setSortOption(option);
-    
+
 
     let sortedPlugins;
     if (option === 'commits') {
@@ -80,7 +80,7 @@ function MainIndex() {
     else if (option == 'alpha') {
       sortedPlugins = plugins;
     }
-    
+
     setSortedData(sortedPlugins);
   };
   return (
@@ -326,7 +326,7 @@ const EntryPoints = ({entryPoints}) => {
 </table>
 
 <table>
-    
+
     <tr>
         <th>Description</th>
     </tr>
@@ -348,7 +348,7 @@ const EntryPoints = ({entryPoints}) => {
         <td>{inputs.info}</td>
       </tr>
     ))}
-    
+
     <tr>
         <th>Outputs</th>
         <th>Required</th>

--- a/aiida-registry-app/src/main.jsx
+++ b/aiida-registry-app/src/main.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx'
-const currentPath = import.meta.env.VITE_BASE_PATH || "/aiida-registry/";
+const currentPath = import.meta.env.VITE_PR_PREVIEW_PATH || "/aiida-registry/";
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter basename={currentPath}>

--- a/aiida-registry-app/src/main.jsx
+++ b/aiida-registry-app/src/main.jsx
@@ -2,8 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom';
 import App from './App.jsx'
-const currentPath = window.location.pathname;
-
+const currentPath = import.meta.env.VITE_BASE_PATH || "/aiida-registry/";
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter basename={currentPath}>

--- a/aiida-registry-app/vite.config.js
+++ b/aiida-registry-app/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-const currentPath = process.env.VITE_BASE_PATH || "/aiida-registry/";
+const currentPath = process.env.VITE_PR_PREVIEW_PATH || "/aiida-registry/";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/aiida-registry-app/vite.config.js
+++ b/aiida-registry-app/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-const currentPath = process.env.BASE_PATH || "/aiida-registry/";
+const currentPath = process.env.VITE_BASE_PATH || "/aiida-registry/";
 
 // https://vitejs.dev/config/
 export default defineConfig({

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -183,8 +183,12 @@ def test_install_all(container_image):
     with open(PLUGINS_METADATA, "r", encoding="utf8") as handle:
         data = json.load(handle)
     print("[test installing plugins]")
+    i = 0
     for plugin_name, plugin in data["plugins"].items():
         print(" - {}".format(plugin["name"]))
+        i+=1
+        if i == 8:
+            break
 
         # this currently checks for the wrong python version
         # if not supports_python_version(plugin):
@@ -206,6 +210,7 @@ def test_install_all(container_image):
 
         results = test_install_one_docker(container_image, plugin)
         process_metadata = results["process_metadata"]
+        data["plugins"][plugin_name]["is_installed"] = str(results["is_installable"])
         for ep_group in ENTRY_POINT_GROUPS:
             try:
                 if process_metadata[ep_group]:

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -209,7 +209,9 @@ def test_install_all(container_image):
         for ep_group in ENTRY_POINT_GROUPS:
             try:
                 if process_metadata[ep_group]:
-                    for key, _ in data["plugins"][plugin_name]["entry_points"][ep_group].items():
+                    for key, _ in data["plugins"][plugin_name]["entry_points"][
+                        ep_group
+                    ].items():
                         data["plugins"][plugin_name]["entry_points"][ep_group][
                             key
                         ] = process_metadata[ep_group][key]

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -183,12 +183,8 @@ def test_install_all(container_image):
     with open(PLUGINS_METADATA, "r", encoding="utf8") as handle:
         data = json.load(handle)
     print("[test installing plugins]")
-    i = 0
     for plugin_name, plugin in data["plugins"].items():
         print(" - {}".format(plugin["name"]))
-        i+=1
-        if i == 8:
-            break
 
         # this currently checks for the wrong python version
         # if not supports_python_version(plugin):
@@ -210,7 +206,7 @@ def test_install_all(container_image):
 
         results = test_install_one_docker(container_image, plugin)
         process_metadata = results["process_metadata"]
-        data["plugins"][plugin_name]["is_installed"] = str(results["is_installable"])
+        data["plugins"][plugin_name]["is_installable"] = str(results["is_installable"])
         for ep_group in ENTRY_POINT_GROUPS:
             try:
                 if process_metadata[ep_group]:

--- a/bin/analyze_entrypoints.py
+++ b/bin/analyze_entrypoints.py
@@ -148,7 +148,6 @@ def document_process_spec(process_spec):
             )
             required = port.required
             info = port.help if port.help is not None else ""
-            info = f"{info[:75]} ..." if len(info) > 75 else info
             result.append(
                 ProcessSpecEntry(
                     name=name, required=required, valid_types=valid_types, info=info


### PR DESCRIPTION
In this PR, the JSON file is modified to include all the entry points information. and then display it in the `EntryPoints` React component.
I also added a sort feature using two options, alphabetical and commits count. These options can be selected using a dropdown list.

## Issues
 * The `webpage` is slow (~35 min) because it depends on `test-install` workflow where the entry points information is collected. @ltalirz introduced a solution here https://github.com/aiidateam/aiida-registry/pull/240#discussion_r1241079352 but I'm not sure when we need to run the `test-install` and when we don't.
 * The description of the inputs/outputs is usually incomplete. 
![image](https://github.com/aiidateam/aiida-registry/assets/62952819/25acecf0-dca7-491d-846d-dc967b9dca5f)
Not sure if it is an issue with data collection or there is no issue to display it as it is.