### PR TITLE
Cache plugins data.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,12 @@ name: CI
 
 on: [push, pull_request]
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
 
   pre-commit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,30 @@ jobs:
       run: pip install --upgrade wheel setuptools
     - name: Install
       run: pip install -e . -v
+
+    - name: Restore cached Plugins
+      id: cache-plugins-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          plugins_metadata.json
+        key: plugins_metadata
+
     - name: fetch metadata
+      if: steps.cache-plugins-restore.outputs.cache-hit != 'true'
       id: fetch_metadata
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
+
+    - name: Cache plugins metadata
+      id: cache-plugins-save
+      uses: actions/cache/save@v3
+      with:
+        path: |
+          plugins_metadata.json
+        key: ${{ steps.cache-plugins-restore.outputs.cache-primary-key }}
+
     - name: Move JSON file to the React project
       run: |
         mv plugins_metadata.json aiida-registry-app/src/
@@ -84,7 +103,17 @@ jobs:
       run: pip install --upgrade pip
     - name: Install
       run: pip install -e . -v
+    - name: Restore cached Plugins
+      id: cache-plugins-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          plugins_metadata.json
+        key: plugins_metadata
+
     - name: fetch metadata
+      if: steps.cache-plugins-restore.outputs.cache-hit != 'true'
+      id: fetch_metadata
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,13 +8,12 @@ on:
       - synchronize
       - closed
 
-concurrency: preview-${{ github.ref }}
-
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
     # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
+
 jobs:
   deploy-preview:
     runs-on: ubuntu-20.04
@@ -32,13 +31,20 @@ jobs:
       run: pip install --upgrade wheel setuptools
     - name: Install
       run: pip install -e . -v
-    - name: fetch metadata
-      id: fetch_metadata
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: aiida-registry fetch
-    - name: Get entry points data
-      run: aiida-registry test-install
+    - name: Get cloned data from gh-pages
+      run: |
+        git remote set-url origin https://github.com/aiidateam/aiida-registry.git
+        git fetch origin gh-pages
+        git checkout origin/gh-pages plugins_metadata.json || true
+
+    # - name: fetch metadata
+    #   id: fetch_metadata
+    #   env:
+    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #   run: aiida-registry fetch
+    # - name: Get entry points data
+    #   run: aiida-registry test-install
+
     - name: Move JSON file to the React project
       run: |
         mv plugins_metadata.json aiida-registry-app/src/

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -37,13 +37,6 @@ jobs:
         git fetch origin gh-pages
         git checkout origin/gh-pages plugins_metadata.json || true
 
-    # - name: fetch metadata
-    #   id: fetch_metadata
-    #   env:
-    #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #   run: aiida-registry fetch
-    # - name: Get entry points data
-    #   run: aiida-registry test-install
 
     - name: Move JSON file to the React project
       run: |

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,6 +10,11 @@ on:
 
 concurrency: preview-${{ github.ref }}
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
 jobs:
   deploy-preview:
     runs-on: ubuntu-20.04

--- a/.github/workflows/webpage.yml
+++ b/.github/workflows/webpage.yml
@@ -42,11 +42,22 @@ jobs:
         git fetch origin gh-pages
         git checkout origin/gh-pages plugins_metadata.json || true
         mv plugins_metadata.json cloned_plugins_metadata.json || true
+
+    - name: Restore cached Plugins
+      id: cache-plugins-restore
+      uses: actions/cache/restore@v3
+      with:
+        path: |
+          plugins_metadata.json
+        key: plugins_metadata
+
     - name: fetch metadata
+      if: steps.cache-plugins-restore.outputs.cache-hit != 'true'
       id: fetch_metadata
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: aiida-registry fetch
+
     - name: Get entry points data
       run: aiida-registry test-install
     - name: Move the JSON file to the React directory

--- a/.github/workflows/webpage.yml
+++ b/.github/workflows/webpage.yml
@@ -11,6 +11,12 @@ on:
     branches:
     - master
 
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   webpage:
     if: github.repository == 'aiidateam/aiida-registry'


### PR DESCRIPTION
This includes attempts to speed up the workflow and limit the API calls to github by caching plugins data.

- In `preview.yml` removed the fetch step and use the data that resides in `gh-pages` instead.
- In `ci.yml`, `webpage` created a cache for plugins data and restored it for each step.
- Setup concurrency to the workflow.

