### PR TITLE
Constraint the running of preview CI only for PR from repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
       uses: ./.github/actions/generate-metadata
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
-        cache: true
+        cache: false
 
     - uses: actions/setup-node@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       working-directory: ./aiida-registry-app
 
   preview:
+    # This job is triggered by (only) a PR to the main branch (not from a fork, not from push)
+    if: (!github.event.pull_request.head.repo.fork) && github.event_name == 'pull_request'
     needs: [test-webpage-build]
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
       working-directory: ./aiida-registry-app
 
   preview:
-    # This job is triggered by (only) a PR to the main branch (not from a fork, not from push)
-    if: (!github.event.pull_request.head.repo.fork) && github.event_name == 'pull_request'
+    # This job is triggered by (only) a PR.
+    if: github.event_name == 'pull_request'
     needs: [test-webpage-build]
     runs-on: ubuntu-latest
     strategy:
@@ -94,7 +94,7 @@ jobs:
       uses: ./.github/actions/generate-metadata
       with:
         gh_token: ${{ secrets.GITHUB_TOKEN }}
-        cache: false
+        cache: true
 
     - uses: actions/setup-node@v3
       with:
@@ -114,3 +114,6 @@ jobs:
         umbrella-dir: pr-preview
         action: auto
         custom-url:
+      # preview will failed if the PR is from a forked repo
+      # should be fixed after https://github.com/aiidateam/aiida-registry/issues/272
+      if: (!github.event.pull_request.head.repo.fork)

--- a/.github/workflows/webpage.yml
+++ b/.github/workflows/webpage.yml
@@ -26,16 +26,11 @@ jobs:
     - name: Create dev environment
       uses: ./.github/actions/create-dev-env
 
-    - name: fetch metadata
-      id: fetch_metadata
-      env:
-        # Use the GITHUB_TOKEN for github API calls
-        # otherwise the rate limit will be exceeded
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: aiida-registry fetch
-    - name: Check plugins installation
-      # This step will attach plugin installation inforamtion to the metadata, e.g. if the plugin can be installed or not
-      run: aiida-registry test-install
+    - name: Generate metadata
+      uses: ./.github/actions/generate-metadata
+      with:
+        gh_token: ${{ secrets.GITHUB_TOKEN }}
+        cache: false
 
     - name: Move JSON file to the React project
       run: |


### PR DESCRIPTION
This PR is from my own repo, so the preview will not run.
This is a good to have change when the PR merge to master, the `preview` should not run.