### PR TITLE
Use new aiida-core docker stack

### DIFF
--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -32,7 +32,10 @@ runs:
         - name: Check plugins installation
           if: ${{ inputs.cache == 'false' }}
           # This step will attach plugin installation inforamtion to the metadata, e.g. if the plugin can be installed or not
-          run: aiida-registry test-install
+          # Make sure the folder is writable
+          run: |
+            umask 000 && chmod +w ../aiida-registry
+            aiida-registry test-install
           shell: bash
         - name: Cache plugins metadata
           if: ${{ inputs.cache == 'false' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    timeout-minutes: 90
+    timeout-minutes: 180
     env:
       COMMIT_AUTHOR: Deploy Action
       COMMIT_AUTHOR_EMAIL: action@github.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    timeout-minutes: 60
+    timeout-minutes: 90
     env:
       COMMIT_AUTHOR: Deploy Action
       COMMIT_AUTHOR_EMAIL: action@github.com

--- a/.github/workflows/webpage.yml
+++ b/.github/workflows/webpage.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   webpage:
+    timeout-minutes: 90
     if: github.repository == 'aiidateam/aiida-registry'
 
     runs-on: ubuntu-latest

--- a/aiida_registry/cli.py
+++ b/aiida_registry/cli.py
@@ -34,8 +34,7 @@ def fetch(package, fetch_pypi, fetch_wheel):  # pylint: disable=unused-argument
 @click.option(
     "--container-image",
     # should use aiidateam/aiida-core-with-services:lastest after the version is released
-    # default="aiidateam/aiida-core-with-services:edge",
-    default="aiidateam/aiida-core:latest",
+    default="aiidateam/aiida-core-with-services:edge",
     help="Container image to use for the install",
 )
 def test_install(container_image):

--- a/aiida_registry/cli.py
+++ b/aiida_registry/cli.py
@@ -12,22 +12,10 @@ def cli():
 
 
 @cli.command()
-@click.argument("package", required=False)
-@click.option(
-    "--fetch-pypi/--no-fetch-pypi",
-    is_flag=True,
-    default=True,
-    help="Allow fetching data from PyPI",
-)
-@click.option(
-    "--fetch-wheel/--no-fetch-wheel",
-    is_flag=True,
-    default=True,
-    help="Allow fetching wheels from PyPI",
-)
-def fetch(package, fetch_pypi, fetch_wheel):  # pylint: disable=unused-argument
+@click.argument("package", nargs=-1, required=False)
+def fetch(package):
     """Fetch data from PyPI and write to JSON file."""
-    make_pages()
+    make_pages(package)
 
 
 @cli.command()

--- a/aiida_registry/make_pages.py
+++ b/aiida_registry/make_pages.py
@@ -142,12 +142,12 @@ def get_pip_install_cmd(plugin_data):
         return "pip install {}".format(pip_url)
 
 
-def make_pages():
+def make_pages(package=None):
     """
     Add additional information to the JSON data like plugins summary,
     global summary, pip install command, and static data.
     """
-    plugins_metadata = fetch_metadata()
+    plugins_metadata = fetch_metadata(filter_list=list(package))
 
     for plugin_name, plugin_data in plugins_metadata.items():
         print("  - {}".format(plugin_name))

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -107,6 +107,10 @@ def test_install_one_docker(container_image, plugin):
             install_package, f"Failed to install plugin {plugin['name']}"
         )
 
+        # Should make this depend on the AiiDA version inside the container,
+        # at least after 2.0 is out that removes reentry
+        _reentry_scan = container.exec_run("reentry scan -r aiida")
+
         is_package_installed = True
 
         if "package_name" not in list(plugin.keys()):

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -107,10 +107,6 @@ def test_install_one_docker(container_image, plugin):
             install_package, f"Failed to install plugin {plugin['name']}"
         )
 
-        # Should make this depend on the AiiDA version inside the container,
-        # at least after 2.0 is out that removes reentry
-        _reentry_scan = container.exec_run("reentry scan -r aiida")
-
         is_package_installed = True
 
         if "package_name" not in list(plugin.keys()):

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -84,7 +84,7 @@ def test_install_one_docker(container_image, plugin):
     """Test installing one plugin in a Docker container."""
     import docker  # pylint: disable=import-outside-toplevel
 
-    client = docker.from_env(timeout=180)
+    client = docker.from_env(timeout=120)
 
     is_package_installed = False
     is_package_importable = False

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -523,3 +523,10 @@ aiida-ssh2win:
   code_home: https://github.com/edan-bainglass/aiida-ssh2win
   version_file: https://raw.githubusercontent.com/edan-bainglass/aiida-ssh2win/develop/aiida_ssh2win/__init__.py
   pip_url: git+https://github.com/edan-bainglass/aiida-ssh2win
+aiida-sssp-workflow:
+  entry_point_prefix: sssp_workflow
+  code_home: https://github.com/aiidateam/aiida-sssp-workflow
+  version_file: https://github.com/aiidateam/aiida-sssp-workflow/blob/main/aiida_sssp_workflow/version.py
+  documentation_url: https://github.com/aiidateam/aiida-sssp-workflow#readme
+  pip_url: aiida-sssp-workflow
+  plugin_info: https://github.com/aiidateam/aiida-sssp-workflow/blob/main/setup.cfg


### PR DESCRIPTION
I need to make the _DOCKER_WORKDIR writable by (o)ther (umask=000) since the new docker stack has default aiida as system user rather than root. This also makes it possible to run on local system that don't have UID=1000.

This PR is blocked by the release of `aiida-core` so the `latest` tag can be used to test the installation of plugins.

supersede #279 