### PR TITLE
Display plugin info fetch failure as error level 

### DIFF
--- a/aiida_registry/__init__.py
+++ b/aiida_registry/__init__.py
@@ -147,8 +147,10 @@ class Reporter:
     def __init__(self):
         """Initialize the reporter."""
         self.warnings = []
+        self.errors = []
         self.plugin_name = None
         self.plugins_warnings = {}
+        self.plugins_errors = {}
 
     def reset(self):
         """Reset the warnings list."""
@@ -174,6 +176,19 @@ class Reporter:
                 self.plugins_warnings[self.plugin_name] = [string]
         else:
             self.warnings.append(message)
+        print(message)
+
+    def error(self, string):
+        """Write to stdout and log."""
+        message = f"  > ERROR! {string}"
+        if self.plugin_name:
+            self.errors.append(f"{message} [{self.plugin_name}]")
+            try:
+                self.plugins_errors[self.plugin_name].append(string)
+            except KeyError:
+                self.plugins_errors[self.plugin_name] = [string]
+        else:
+            self.errors.append(message)
         print(message)
 
     def info(self, string):

--- a/aiida_registry/cli.py
+++ b/aiida_registry/cli.py
@@ -12,22 +12,10 @@ def cli():
 
 
 @cli.command()
-@click.argument("package", required=False)
-@click.option(
-    "--fetch-pypi/--no-fetch-pypi",
-    is_flag=True,
-    default=True,
-    help="Allow fetching data from PyPI",
-)
-@click.option(
-    "--fetch-wheel/--no-fetch-wheel",
-    is_flag=True,
-    default=True,
-    help="Allow fetching wheels from PyPI",
-)
-def fetch(package, fetch_pypi, fetch_wheel):  # pylint: disable=unused-argument
+@click.argument("package", nargs=-1, required=False)
+def fetch(package):
     """Fetch data from PyPI and write to JSON file."""
-    make_pages()
+    make_pages(package)
 
 
 @cli.command()

--- a/aiida_registry/make_pages.py
+++ b/aiida_registry/make_pages.py
@@ -142,12 +142,12 @@ def get_pip_install_cmd(plugin_data):
         return "pip install {}".format(pip_url)
 
 
-def make_pages():
+def make_pages(package=None):
     """
     Add additional information to the JSON data like plugins summary,
     global summary, pip install command, and static data.
     """
-    plugins_metadata = fetch_metadata()
+    plugins_metadata = fetch_metadata(filter_list=list(package))
 
     for plugin_name, plugin_data in plugins_metadata.items():
         print("  - {}".format(plugin_name))

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -10,7 +10,7 @@ import os
 import sys
 from dataclasses import asdict, dataclass
 
-from aiida_registry.fetch_metadata import add_registry_checks
+from aiida_registry.utils import add_registry_checks
 
 from . import PLUGINS_METADATA, REPORTER
 
@@ -74,7 +74,7 @@ def handle_error(process_result, message):
 
     if process_result.exit_code != 0:
         error_message = process_result.output.decode("utf8")
-        REPORTER.warn(f"{message}\n{error_message}")
+        REPORTER.error(f"{message}\n{error_message}")
         raise ValueError(f"{message}\n{error_message}")
 
     return error_message
@@ -223,7 +223,7 @@ def test_install_all(container_image):
             except KeyError:
                 continue
 
-    data = add_registry_checks(data, include_errors=True)
+        data["plugins"] = add_registry_checks(data["plugins"])
 
     print("Dumping plugins.json")
     with open(PLUGINS_METADATA, "w", encoding="utf8") as handle:

--- a/aiida_registry/utils.py
+++ b/aiida_registry/utils.py
@@ -22,9 +22,25 @@ def fetch_file(file_url: str, file_type: str = "plugin info", warn=True) -> str:
         response.raise_for_status()
     except Exception:  # pylint: disable=broad-except
         if warn:
-            REPORTER.warn(
-                f"  > WARNING! Unable to retrieve {file_type} from: {file_url}"
+            REPORTER.error(
+                f"Unable to retrieve {file_type} from: {file_url}."
+                "Please check the URL of your plugin in the registry yaml."
             )
             REPORTER.debug(traceback.format_exc())
         return None
     return response.content.decode(response.encoding or "utf8")
+
+
+def add_registry_checks(metadata):
+    """Add fetch warnings/errors to the data object."""
+    for name, error_list in REPORTER.plugins_errors.items():
+        if "errors" not in metadata[name]:
+            metadata[name]["errors"] = []
+        metadata[name]["errors"] += error_list
+
+    for name, warning_list in REPORTER.plugins_warnings.items():
+        if "warnings" not in metadata[name]:
+            metadata[name]["warnings"] = []
+        metadata[name]["warnings"] += warning_list
+
+    return metadata


### PR DESCRIPTION
Allow passing plugin name to `aiida-registry fetch` to accelerate testing locally.

Include some more tidying up on the code

always print errors

extend error/warning to result

Remove unused get_last_fetch_version function