### PR TITLE
DOC: guide developer to fix registry checks warnings/errors

### DIFF
--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -56,7 +56,7 @@ runs:
           env:
             GITHUB_TOKEN: ${{ inputs.gh_token }}
           run: |
-            aiida-registry fetch
+            aiida-registry fetch aiida-kkr aiida-fleur aiida-gudhi aiida-defects
           shell: bash
 
         - name: Check installation of plugins

--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -66,7 +66,6 @@ runs:
           shell: bash
 
         - name: Move JSON file to the React project
-          if: always()
           run: |
             mkdir -p aiida-registry-app/dist
             cp plugins_metadata.json aiida-registry-app/src/

--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -56,7 +56,7 @@ runs:
           env:
             GITHUB_TOKEN: ${{ inputs.gh_token }}
           run: |
-            aiida-registry fetch aiida-kkr aiida-fleur aiida-gudhi aiida-defects
+            aiida-registry fetch
           shell: bash
 
         - name: Check installation of plugins

--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -66,6 +66,7 @@ runs:
           shell: bash
 
         - name: Move JSON file to the React project
+          if: always()
           run: |
             mkdir -p aiida-registry-app/dist
             cp plugins_metadata.json aiida-registry-app/src/

--- a/README.md
+++ b/README.md
@@ -72,3 +72,22 @@ The development status of a plugin used to be recorded explicitly on the plugin 
 Over time, we've moved closer and closer to adopting the [development status trove classifer](https://pypi.org/classifiers/), so we now suggest to just use those in your `setup.json`/`setup.cfg`/... file of your plugin.
 
 If no development status is specified, the status will default to 'planning'.
+
+## How to run the registry check locally
+
+You may want to check that your plugin is correctly registered before making the changes to your plugin repository.
+To do so, you can run the registry check locally.
+
+Clone this repository and install the dependencies:
+```bash
+git clone https://github.com/aiidateam/aiida-registry.git
+pip install aiida-registry
+```
+
+Fetch the metadata and run installation test or your plugin
+```bash
+aiida-registry fetch-metadata <plugin-name>
+aiida-registry test-install
+```
+
+You'll see the warnings and errors as what you can see from the registry page.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,78 @@ You'll see the warnings and errors as what you can see from the registry page.
 - **Cause**: The plugin does not have the classifier `Framework :: AiiDA` in the plugin metadata (e.g. `setup.json`, `pyproject.toml`, `setup.cfg`).
 - **Solution**: Add the classifier `Framework :: AiiDA` to the plugin metadata.
 
+#### W004
+
+- **Message**: Multiple development statuses found in classifiers
+
+#### W005
+
+- **Message**: Development status in classifiers not match development status in metadata
+
+#### W006
+
+- **Message**: `development_status` is deprecated.
+
+#### W007
+
+- **Message**: Invalid development status.
+
+#### W008
+
+- **Message**: Unable to reach documentation URL.
+
+#### W009
+
+- **Message**: Prefix of entry points does not follow naming convention.
+- **Cause**: The prefix of entry points does not match the convention of package name, where if you have package `aiida-xxx`, the prefix of entry points should be `xxx`.
+- **Solution**: Change the prefix of entry points to match the convention.
+
+#### W010
+
+- **Message**: Entry point does not start with proper prefix.
+
+#### W011
+
+- **Message**: Unable to parse TOML.
+
+
+#### W012
+
+- **Message**: Unknown build system in `pyproject.toml`.
+
+#### W013
+
+- **Message**: Unknown build system.
+
+#### W014
+
+- **Message**: Unable to parse JSON.
+
+
+#### W015
+
+- **Message**: Version & description metadata are not (yet) parsed from the flit build system in `pyproject.toml`.
+
+#### W016
+
+- **Message**: Unable to parse `setup.cfg`.
+
+#### W017
+
+- **Message**: Invalid version encontered in Poery `pyproject.toml` for `aiida-core`.
+
+#### W018
+
+- **Message**: Unable to parse module of the package to futher parse the version from.
+
+#### W019
+
+- **Message**: No `bdist_wheel` available for PyPI release.
+
+#### W020
+
+- **Message**: Unable to read wheel file from PyPI release.
+
 #### E001
 
 - **Message**: Failed to install the plugin

--- a/README.md
+++ b/README.md
@@ -78,22 +78,7 @@ If no development status is specified, the status will default to 'planning'.
 
 ## How to fix registry warnings and errors
 
-You may want to check that your plugin is correctly registered before making the changes to your plugin repository.
-To do so, you can run the registry check locally.
-
-Clone this repository and install the dependencies:
-```bash
-git clone https://github.com/aiidateam/aiida-registry.git
-pip install aiida-registry
-```
-
-Fetch the metadata and run installation test or your plugin
-```bash
-aiida-registry fetch-metadata <plugin-name>
-aiida-registry test-install
-```
-
-You'll see the warnings and errors as what you can see from the registry page.
+You can reproduce the warnings/errors locally through the [instructions](https://github.com/aiidateam/aiida-registry/wiki#how-to-fix-registry-warnings-and-errors).
 
 ### Warning/Error codes
 

--- a/README.md
+++ b/README.md
@@ -118,22 +118,32 @@ You'll see the warnings and errors as what you can see from the registry page.
 #### W004
 
 - **Message**: Multiple development statuses found in classifiers
+- **Cause**: The plugin has multiple development statuses in the plugin metadata.
+- **Solution**: Remove the extra development status from the plugin metadata.
 
 #### W005
 
 - **Message**: Development status in classifiers not match development status in metadata
+- **Cause**: The development status in the plugin metadata does not match the "developments_status" (deprecated, and defined in `plugins.yaml`).
+- **Solution**: Use [development status trove classifer](https://pypi.org/classifiers/) only.
 
 #### W006
 
 - **Message**: `development_status` is deprecated.
+- **Cause**: The `development_status` key is found in `plugins.yaml`.
+- **Solution**: Use [development status trove classifer](https://pypi.org/classifiers/).
 
 #### W007
 
 - **Message**: Invalid development status.
+- **Cause**: The development status is not one of the following: `planning`, `pre-alpha`, `alpha`, `beta`, `stable`, `mature`, `inactive`.
+- **Solution**: Use one of the following development status: `planning`, `pre-alpha`, `alpha`, `beta`, `stable`, `mature`, `inactive`. But note that `development_status` is deprecated and you should use [development status trove classifer](https://pypi.org/classifiers/) instead.
 
 #### W008
 
 - **Message**: Unable to reach documentation URL.
+- **Cause**: The documentation URL is not reachable.
+- **Solution**: Check the documentation URL is correctly defined in `plugins.yaml`.
 
 #### W009
 
@@ -144,48 +154,68 @@ You'll see the warnings and errors as what you can see from the registry page.
 #### W010
 
 - **Message**: Entry point does not start with proper prefix.
+- **Cause**: The entry point does not start with the prefix defined in `plugins.yaml`.
+- **Solution**: Change the entry point to start with the prefix defined in `plugins.yaml`.
 
 #### W011
 
 - **Message**: Unable to parse TOML.
-
+- **Cause**: The `pyproject.toml` cannot be parsed.
+- **Solution**: Check the `pyproject.toml` is correctly formatted.
 
 #### W012
 
 - **Message**: Unknown build system in `pyproject.toml`.
+- **Cause**: The build system in `pyproject.toml` is not one of the following, check [PEP621](https://peps.python.org/pep-0621/): `setuptools`, `flit`, `poetry`.
+- **Solution**: Use one of the following build system: `setuptools`, `flit`, `poetry`.
 
 #### W013
 
 - **Message**: Unknown build system.
+- **Cause**: The build tool is not valid. We support setuptools (`setup.cfg`, `setup.json`), flit (`pyproject.toml`), poetry (`pyproject.toml`).
+- **Solution**: Use one of the following build system: `setuptools`, `flit`, `poetry`.
 
 #### W014
 
-- **Message**: Unable to parse JSON.
-
+- **Message**: Unable to parse setup JSON.
+- **Cause**: The `setup.json` cannot be parsed.
+- **Solution**: Check the `setup.json` is correctly formatted.
 
 #### W015
 
 - **Message**: Version & description metadata are not (yet) parsed from the flit build system in `pyproject.toml`.
+- **Cause**: The version & description metadata are not (yet) parsed from the flit build system in `pyproject.toml`.
+- **Solution**: Add the version & description metadata to the `pyproject.toml`.
 
 #### W016
 
 - **Message**: Unable to parse `setup.cfg`.
+- **Cause**: The `setup.cfg` cannot be parsed.
+- **Solution**: Check the `setup.cfg` is correctly formatted.
 
 #### W017
 
 - **Message**: Invalid version encontered in Poery `pyproject.toml` for `aiida-core`.
+- **Cause**: The version of `aiida-core` in `pyproject.toml` is not valid.
+- **Solution**: Check the version of `aiida-core` in `pyproject.toml` is valid and correct.
 
 #### W018
 
 - **Message**: Unable to parse module of the package to futher parse the version from.
+- **Cause**: The module of the package cannot be parsed.
+- **Solution**: Check the module of the package is correctly formatted.
 
 #### W019
 
 - **Message**: No `bdist_wheel` available for PyPI release.
+- **Cause**: The `bdist_wheel` is not available for PyPI release.
+- **Solution**: Check the `bdist_wheel` is available for PyPI release.
 
 #### W020
 
 - **Message**: Unable to read wheel file from PyPI release.
+- **Cause**: The wheel file cannot be read from PyPI release.
+- **Solution**: Check the wheel file is correctly formatted.
 
 #### E001
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ We strongly encourage to **register at early stages of development**,
 since this both "reserves" the name of your plugin and informs the developer
 community of your ongoing work.
 
+By default, the list of plugins is now sorted by the latest release, so plugins that are under active development automatically bubble up to the top.
+The release date is determined by the date of the latest [PyPI](https://pypi.org/) release, so try to release to [PyPI](https://pypi.org/) whenever you make a new release of your plugin.
+
 ## How to register a plugin
 
 1. Fork this repository
@@ -73,7 +76,7 @@ Over time, we've moved closer and closer to adopting the [development status tro
 
 If no development status is specified, the status will default to 'planning'.
 
-## How to run the registry check locally
+## How to fix registry warnings and errors
 
 You may want to check that your plugin is correctly registered before making the changes to your plugin repository.
 To do so, you can run the registry check locally.
@@ -91,3 +94,47 @@ aiida-registry test-install
 ```
 
 You'll see the warnings and errors as what you can see from the registry page.
+
+### Warning/Error codes
+
+#### W001
+
+- **Message**: Cannot fetch all data from PyPI and missing plugin_info key!
+- **Cause**: The plugin is not registered on PyPI and the `plugin_info` key is missing.
+- **Solution**: Register your plugin on PyPI or add the `plugin_info` key pointing to the correct plugin_info file.
+
+#### W002
+
+- **Message**: AiiDA version not found
+- **Cause**: `aiida-core` is not found in the plugin requirements.
+- **Solution**: Add `aiida-core` to the plugin requirements with the version specifier.
+
+#### W003
+
+- **Message**: Missing classifier 'Framework :: AiiDA'
+- **Cause**: The plugin does not have the classifier `Framework :: AiiDA` in the plugin metadata (e.g. `setup.json`, `pyproject.toml`, `setup.cfg`).
+- **Solution**: Add the classifier `Framework :: AiiDA` to the plugin metadata.
+
+#### E001
+
+- **Message**: Failed to install the plugin
+- **Cause**: The plugin cannot be installed with `pip install --pre`.
+- **Solution**: Fix the installation of the plugin.
+
+#### E002
+
+- **Message**: Failed to import the plugin
+- **Cause**: The plugin cannot be imported.
+- **Solution**: Fix the import of the plugin.
+
+#### E003
+
+- **Message**: Failed to fetch entry point metadata for package
+- **Cause**: The entry point metadata cannot be fetched.
+- **Solution**: Check to see if the entry point metadata is correct.
+
+#### E004
+
+- **Message**: Unable to retrieve plugin metadata
+- **Cause**: The plugin metadata cannot be retrieved.
+- **Solution**: Check the URL of your plugin info URL in [plugins.yaml](plugins.yaml) is correct.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ since this both "reserves" the name of your plugin and informs the developer
 community of your ongoing work.
 
 By default, the list of plugins is now sorted by the latest release, so plugins that are under active development automatically bubble up to the top.
-The release date is determined by the date of the latest [PyPI](https://pypi.org/) release, so try to release to [PyPI](https://pypi.org/) whenever you make a new release of your plugin.
+The release date is determined by the date of the latest [PyPI](https://pypi.org/) release. Plugins not released to PyPI will have no release date.
 
 ## How to register a plugin
 

--- a/aiida-registry-app/src/Components/Details.jsx
+++ b/aiida-registry-app/src/Components/Details.jsx
@@ -93,6 +93,9 @@ function Details({pluginKey}) {
           ))}
             </>
           )}
+          <Alert severity="info">
+            Please check <a href="https://github.com/aiidateam/aiida-registry#how-to-fix-registry-warnings-and-errors">the registry checks troubleshooting guide</a> to see how to run checks locally to anchor and fix the warnings/errors.
+          </Alert>
         </>
       ) : (
         <Alert severity="success">All checks passed!</Alert>

--- a/aiida-registry-app/src/Components/Details.jsx
+++ b/aiida-registry-app/src/Components/Details.jsx
@@ -94,7 +94,7 @@ function Details({pluginKey}) {
             </>
           )}
           <Alert severity="info">
-            Please check <a href="https://github.com/aiidateam/aiida-registry#how-to-fix-registry-warnings-and-errors">the registry checks troubleshooting guide</a> to see how to run checks locally to anchor and fix the warnings/errors.
+            Click the warning/error code will redirect to <a href="https://github.com/aiidateam/aiida-registry#how-to-fix-registry-warnings-and-errors">troubleshooting section</a> for the fix of the issue.
           </Alert>
         </>
       ) : (

--- a/aiida_registry/__init__.py
+++ b/aiida_registry/__init__.py
@@ -172,7 +172,6 @@ class Reporter:
         """
         # Set the step output error message which can be used,
         # e.g., for display as part of an issue comment.
-        output = f" > <strong>WARNING!</strong> {string}"
         if self.plugin_name:
             self.warnings.append(f"{message} [{self.plugin_name}]")
             self.plugins_warnings[self.plugin_name].append(message)

--- a/aiida_registry/__init__.py
+++ b/aiida_registry/__init__.py
@@ -165,13 +165,16 @@ class Reporter:
         self.plugins_warnings[self.plugin_name] = []
         self.plugins_errors[self.plugin_name] = []
 
-    def warn(self, message):
+    def warn(self, message, check_id=None):
         """Write to stdout and log.
 
         Used to display log in actions.
         """
         # Set the step output error message which can be used,
         # e.g., for display as part of an issue comment.
+        if check_id is not None:
+            message = f"<a href='https://github.com/aiidateam/aiida-registry#{check_id}'>{check_id}</a>: {message}"
+
         if self.plugin_name:
             self.warnings.append(f"{message} [{self.plugin_name}]")
             self.plugins_warnings[self.plugin_name].append(message)
@@ -179,8 +182,11 @@ class Reporter:
             self.warnings.append(f"{message}")
         print(f"{message}")
 
-    def error(self, message):
+    def error(self, message, check_id=None):
         """Write to stdout and log."""
+        if check_id is not None:
+            message = f"<a href='https://github.com/aiidateam/aiida-registry#{check_id}'>{check_id}</a>: {message}"
+
         if self.plugin_name:
             self.errors.append(f"{message} [{self.plugin_name}]")
             self.plugins_errors[self.plugin_name].append(message)

--- a/aiida_registry/__init__.py
+++ b/aiida_registry/__init__.py
@@ -172,6 +172,7 @@ class Reporter:
         """
         # Set the step output error message which can be used,
         # e.g., for display as part of an issue comment.
+        output = f" > <strong>WARNING!</strong> {string}"
         if self.plugin_name:
             self.warnings.append(f"{message} [{self.plugin_name}]")
             self.plugins_warnings[self.plugin_name].append(message)

--- a/aiida_registry/fetch_metadata.py
+++ b/aiida_registry/fetch_metadata.py
@@ -277,7 +277,7 @@ def validate_dev_status(plugin_data: dict):
     if "development_status" in plugin_data:
         REPORTER.warn(
             "<a href='https://github.com/aiidateam/aiida-registry#W006'>W006</a>: "
-            "`development_status` key is deprecated. "
+            "<code>development_status</code> key is deprecated. "
             "Use PyPI Trove classifiers in the plugin repository instead."
         )
     else:

--- a/aiida_registry/fetch_metadata.py
+++ b/aiida_registry/fetch_metadata.py
@@ -188,8 +188,8 @@ def complete_plugin_data(
         plugin_info_url = plugin_data.pop("plugin_info", None)
         if plugin_info_url is None:
             REPORTER.warn(
-                "<a href='https://github.com/aiidateam/aiida-registry#W001'>W001</a>: "
-                "Cannot fetch all data from PyPI and missing plugin_info key!"
+                "Cannot fetch all data from PyPI and missing plugin_info key!",
+                check_id="E001",
             )
         else:
             # retrieve content of build file
@@ -224,8 +224,8 @@ def complete_plugin_data(
         plugin_data["aiida_version"] = f'=={plugin_data["metadata"]["version"]}'
     if plugin_data.get("aiida_version") is None:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W002'>W002</a>: "
-            "AiiDA version not found"
+            "AiiDA version not found",
+            check_id="W002",
         )
 
     validate_dev_status(plugin_data)
@@ -247,8 +247,8 @@ def validate_dev_status(plugin_data: dict):
     )
     if plugin_data["metadata"] and "Framework :: AiiDA" not in classifiers:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W003'>W003</a>: "
-            "Missing classifier 'Framework :: AiiDA'"
+            "Missing classifier 'Framework :: AiiDA'",
+            check_id="W003",
         )
 
     # Read development status from plugin repo
@@ -257,8 +257,8 @@ def validate_dev_status(plugin_data: dict):
         if classifier in classifier_to_status:
             if development_status is not None:
                 REPORTER.warn(
-                    "<a href='https://github.com/aiidateam/aiida-registry#W004'>W004</a>: "
-                    "Multiple development statuses found in classifiers"
+                    "Multiple development statuses found in classifiers",
+                    check_id="W004",
                 )
             development_status = classifier_to_status[classifier]
 
@@ -268,17 +268,17 @@ def validate_dev_status(plugin_data: dict):
         and (development_status != plugin_data["development_status"])
     ):
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W005'>W005</a>: "
             f"Development status in classifiers ({development_status}) "
-            f"does not match development_status in metadata ({plugin_data['development_status']})"
+            f"does not match development_status in metadata ({plugin_data['development_status']})",
+            check_id="W005",
         )
 
     # prioritise development_status from plugins.yaml
     if "development_status" in plugin_data:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W006'>W006</a>: "
-            "<code>development_status</code> key is deprecated. "
-            "Use PyPI Trove classifiers in the plugin repository instead."
+            "'development_status' key is deprecated. "
+            "Use PyPI Trove classifiers in the plugin repository instead.",
+            check_id="W006",
         )
     else:
         plugin_data["development_status"] = development_status or "planning"
@@ -286,8 +286,8 @@ def validate_dev_status(plugin_data: dict):
     # note: for more validation, it might be sensible to switch to voluptuous
     if plugin_data["development_status"] not in status_dict:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W007'>W007</a>: "
-            f"Invalid development status '{plugin_data['development_status']}'"
+            f"Invalid development status '{plugin_data['development_status']}'",
+            check_id="W007",
         )
 
 
@@ -298,8 +298,8 @@ def validate_doc_url(url):
         response.raise_for_status()  # raise an exception for all 4xx/5xx errors
     except Exception:  # pylint: disable=broad-except
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W008'>W008</a>: "
-            f"Unable to reach documentation URL: {url}"
+            f"Unable to reach documentation URL: {url}",
+            check_id="W008",
         )
         REPORTER.debug(traceback.print_exc(file=sys.stdout))
 
@@ -316,8 +316,8 @@ def validate_plugin_entry_points(plugin_data):
             == plugin_data["package_name"].lower()
         ):
             REPORTER.warn(
-                "<a href='https://github.com/aiidateam/aiida-registry#W009'>W009</a>: "
-                f"Prefix '{plugin_data['entry_point_prefix']}' does not follow naming convention."
+                f"Prefix '{plugin_data['entry_point_prefix']}' does not follow naming convention.",
+                check_id="W009",
             )
     else:
         # plugin should not specify any entry points
@@ -334,8 +334,8 @@ def validate_plugin_entry_points(plugin_data):
                 ept_string = ept_string.strip()
             if not ept_string.startswith(entry_point_root):
                 REPORTER.warn(
-                    "<a href='https://github.com/aiidateam/aiida-registry#W010'>W010</a>: "
-                    f"Entry point '{ept_string}' does not start with prefix '{entry_point_root}.'"
+                    f"Entry point '{ept_string}' does not start with prefix '{entry_point_root}.'",
+                    check_id="W010",
                 )
 
 
@@ -365,8 +365,5 @@ def fetch_metadata(filter_list=None, fetch_pypi=True, fetch_pypi_wheel=True):
         )
     plugins_metadata = add_registry_checks(plugins_metadata)
     REPORTER.info(f"{PLUGINS_METADATA} dumped")
-
-    if os.environ.get("GITHUB_ACTIONS") == "true":
-        print("::set-output name=error::" + "%0A".join(REPORTER.warnings))
 
     return plugins_metadata

--- a/aiida_registry/fetch_metadata.py
+++ b/aiida_registry/fetch_metadata.py
@@ -188,6 +188,7 @@ def complete_plugin_data(
         plugin_info_url = plugin_data.pop("plugin_info", None)
         if plugin_info_url is None:
             REPORTER.warn(
+                "<a href='https://github.com/aiidateam/aiida-registry#W001'>W001</a>: "
                 "Cannot fetch all data from PyPI and missing plugin_info key!"
             )
         else:
@@ -222,7 +223,10 @@ def complete_plugin_data(
     if plugin_data["name"] == "aiida-core" and plugin_data["metadata"].get("version"):
         plugin_data["aiida_version"] = f'=={plugin_data["metadata"]["version"]}'
     if plugin_data.get("aiida_version") is None:
-        REPORTER.warn("AiiDA version not found")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W002'>W002</a>: "
+            "AiiDA version not found"
+        )
 
     validate_dev_status(plugin_data)
 
@@ -242,14 +246,20 @@ def validate_dev_status(plugin_data: dict):
         else []
     )
     if plugin_data["metadata"] and "Framework :: AiiDA" not in classifiers:
-        REPORTER.warn("Missing classifier 'Framework :: AiiDA'")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W003'>W003</a>: "
+            "Missing classifier 'Framework :: AiiDA'"
+        )
 
     # Read development status from plugin repo
     development_status = None
     for classifier in classifiers:
         if classifier in classifier_to_status:
             if development_status is not None:
-                REPORTER.warn("Multiple development statuses found in classifiers")
+                REPORTER.warn(
+                    "<a href='https://github.com/aiidateam/aiida-registry#W004'>W004</a>: "
+                    "Multiple development statuses found in classifiers"
+                )
             development_status = classifier_to_status[classifier]
 
     if (
@@ -258,6 +268,7 @@ def validate_dev_status(plugin_data: dict):
         and (development_status != plugin_data["development_status"])
     ):
         REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W005'>W005</a>: "
             f"Development status in classifiers ({development_status}) "
             f"does not match development_status in metadata ({plugin_data['development_status']})"
         )
@@ -265,6 +276,7 @@ def validate_dev_status(plugin_data: dict):
     # prioritise development_status from plugins.yaml
     if "development_status" in plugin_data:
         REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W006'>W006</a>: "
             "`development_status` key is deprecated. "
             "Use PyPI Trove classifiers in the plugin repository instead."
         )
@@ -274,7 +286,8 @@ def validate_dev_status(plugin_data: dict):
     # note: for more validation, it might be sensible to switch to voluptuous
     if plugin_data["development_status"] not in status_dict:
         REPORTER.warn(
-            "Invalid development status '{}'".format(plugin_data["development_status"])
+            "<a href='https://github.com/aiidateam/aiida-registry#W007'>W007</a>: "
+            f"Invalid development status '{plugin_data['development_status']}'"
         )
 
 
@@ -284,7 +297,10 @@ def validate_doc_url(url):
         response = requests.get(url, timeout=60)
         response.raise_for_status()  # raise an exception for all 4xx/5xx errors
     except Exception:  # pylint: disable=broad-except
-        REPORTER.warn("Unable to reach documentation URL: {}".format(url))
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W008'>W008</a>: "
+            f"Unable to reach documentation URL: {url}"
+        )
         REPORTER.debug(traceback.print_exc(file=sys.stdout))
 
 
@@ -300,6 +316,7 @@ def validate_plugin_entry_points(plugin_data):
             == plugin_data["package_name"].lower()
         ):
             REPORTER.warn(
+                "<a href='https://github.com/aiidateam/aiida-registry#W009'>W009</a>: "
                 f"Prefix '{plugin_data['entry_point_prefix']}' does not follow naming convention."
             )
     else:
@@ -317,6 +334,7 @@ def validate_plugin_entry_points(plugin_data):
                 ept_string = ept_string.strip()
             if not ept_string.startswith(entry_point_root):
                 REPORTER.warn(
+                    "<a href='https://github.com/aiidateam/aiida-registry#W010'>W010</a>: "
                     f"Entry point '{ept_string}' does not start with prefix '{entry_point_root}.'"
                 )
 

--- a/aiida_registry/parse_build_file.py
+++ b/aiida_registry/parse_build_file.py
@@ -54,8 +54,8 @@ def identify_build_tool(url: str, content: str) -> Optional[str]:
             return "FLIT_OLD"
 
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W012'>W012</a>: "
-            f"Unknown build system in pyproject.toml: {tool_name}"
+            f"Unknown build system in pyproject.toml: {tool_name}",
+            check_id="W012",
         )
         return None
 
@@ -66,8 +66,8 @@ def identify_build_tool(url: str, content: str) -> Optional[str]:
         return "SETUPTOOLS_JSON"
 
     REPORTER.warn(
-        "<a href='https://github.com/aiidateam/aiida-registry#W013'>W013</a>: "
-        f"Unknown build system: {url}"
+        f"Unknown build tool: {url}",
+        check_id="W013",
     )
     return None
 
@@ -89,8 +89,8 @@ def parse_toml(content: str) -> Optional[TOMLDocument]:
         return tomlkit.parse(content)
     except tomlkit.exceptions.TOMLKitError as exc:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W011'>W011</a>: "
-            f"Unable to parse TOML: {exc}"
+            f"Unable to parse TOML: {exc}",
+            check_id="W011",
         )
         raise exc
 
@@ -133,8 +133,8 @@ def parse_setup_json(content: str, ep_only=False) -> SourceData:
         data = json.loads(content)
     except ValueError as exc:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W014'>W014</a>: "
-            f"Unable to parse JSON: {exc}"
+            f"Unable to parse setup JSON: {exc}",
+            check_id="W014",
         )
         return SourceData()
 
@@ -204,9 +204,9 @@ def parse_flit_old(content: str, ep_only=False) -> SourceData:
     # author is a mandatory field in Flit
 
     REPORTER.warn(
-        "<a href='https://github.com/aiidateam/aiida-registry#W015'>W015</a>: "
         "Version & description metadata are not (yet) "
-        "parsed from the flit build system `pyproject.toml`."
+        "parsed from the flit build system `pyproject.toml`.",
+        check_id="W015",
     )
     metadata = data["tool"]["flit"].get("metadata", {})
     infos = {
@@ -229,8 +229,8 @@ def parse_setup_cfg(content: str, ep_only=False) -> SourceData:
         config.read_string(content)
     except Exception as exc:  # pylint: disable=broad-except
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W016'>W016</a>: "
-            f"Unable to parse setup.cfg: {exc}"
+            f"Unable to parse setup.cfg: {exc}",
+            check_id="W016",
         )
         return SourceData()
 
@@ -321,8 +321,8 @@ def get_aiida_version_poetry(pyproject):
         return str(parse_constraint(version))
     except ValueError:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W017'>W017</a>: "
-            "Invalid version encountered in Poetry `pyproject.toml` for aiida-core"
+            "Invalid version encountered in Poetry `pyproject.toml` for aiida-core",
+            check_id="W017",
         )
 
     return None
@@ -335,8 +335,8 @@ def get_version_from_module(content: str) -> Optional[str]:
         module = ast.parse(content)
     except SyntaxError as exc:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W018'>W018</a>: "
-            f"Unable to parse module of the package to futher parse the version from: {exc}"
+            f"Unable to parse module of the package to futher parse the version from: {exc}",
+            check_id="W018",
         )
         return None
     try:

--- a/aiida_registry/parse_build_file.py
+++ b/aiida_registry/parse_build_file.py
@@ -40,9 +40,8 @@ def identify_build_tool(url: str, content: str) -> Optional[str]:
     # pylint: disable=too-many-return-statements
     if "pyproject.toml" in url:
         try:
-            pyproject = tomlkit.parse(content)
-        except tomlkit.exceptions.TOMLKitError as exc:
-            REPORTER.warn(f"Unable to parse TOML: {exc}")
+            pyproject = parse_toml(content)
+        except tomlkit.exceptions.TOMLKitError:
             return None
 
         if "project" in pyproject:
@@ -54,7 +53,10 @@ def identify_build_tool(url: str, content: str) -> Optional[str]:
         if "flit" in tool_name:
             return "FLIT_OLD"
 
-        REPORTER.warn(f"Unknown build system in pyproject.toml: {tool_name}")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W012'>W012</a>: "
+            f"Unknown build system in pyproject.toml: {tool_name}"
+        )
         return None
 
     if "setup.cfg" in url:
@@ -63,7 +65,10 @@ def identify_build_tool(url: str, content: str) -> Optional[str]:
     if "setup.json" in url:
         return "SETUPTOOLS_JSON"
 
-    REPORTER.warn(f"Unknown build system: {url}")
+    REPORTER.warn(
+        "<a href='https://github.com/aiidateam/aiida-registry#W013'>W013</a>: "
+        f"Unknown build system: {url}"
+    )
     return None
 
 
@@ -83,8 +88,11 @@ def parse_toml(content: str) -> Optional[TOMLDocument]:
     try:
         return tomlkit.parse(content)
     except tomlkit.exceptions.TOMLKitError as exc:
-        REPORTER.warn(f"Unable to parse TOML: {exc}")
-    return None
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W011'>W011</a>: "
+            f"Unable to parse TOML: {exc}"
+        )
+        raise exc
 
 
 def parse_pep_621(content: str, ep_only=False) -> SourceData:
@@ -124,7 +132,10 @@ def parse_setup_json(content: str, ep_only=False) -> SourceData:
     try:
         data = json.loads(content)
     except ValueError as exc:
-        REPORTER.warn(f"Unable to parse JSON: {exc}")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W014'>W014</a>: "
+            f"Unable to parse JSON: {exc}"
+        )
         return SourceData()
 
     entry_points = {
@@ -193,8 +204,9 @@ def parse_flit_old(content: str, ep_only=False) -> SourceData:
     # author is a mandatory field in Flit
 
     REPORTER.warn(
-        "version & description metadata"
-        " are not (yet) parsed from the Flit buildsystem pyproject.toml"
+        "<a href='https://github.com/aiidateam/aiida-registry#W015'>W015</a>: "
+        "Version & description metadata are not (yet) "
+        "parsed from the flit build system `pyproject.toml`."
     )
     metadata = data["tool"]["flit"].get("metadata", {})
     infos = {
@@ -216,7 +228,10 @@ def parse_setup_cfg(content: str, ep_only=False) -> SourceData:
         config = ConfigParser()
         config.read_string(content)
     except Exception as exc:  # pylint: disable=broad-except
-        REPORTER.warn(f"Unable to parse setup.cfg: {exc}")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W016'>W016</a>: "
+            f"Unable to parse setup.cfg: {exc}"
+        )
         return SourceData()
 
     entry_points = {}
@@ -306,7 +321,8 @@ def get_aiida_version_poetry(pyproject):
         return str(parse_constraint(version))
     except ValueError:
         REPORTER.warn(
-            "Invalid version encountered in Poetry pyproject.toml for aiida-core"
+            "<a href='https://github.com/aiidateam/aiida-registry#W017'>W017</a>: "
+            "Invalid version encountered in Poetry `pyproject.toml` for aiida-core"
         )
 
     return None
@@ -318,7 +334,10 @@ def get_version_from_module(content: str) -> Optional[str]:
     try:
         module = ast.parse(content)
     except SyntaxError as exc:
-        REPORTER.warn(f"Unable to parse module: {exc}")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W018'>W018</a>: "
+            f"Unable to parse module of the package to futher parse the version from: {exc}"
+        )
         return None
     try:
         return next(

--- a/aiida_registry/parse_pypi.py
+++ b/aiida_registry/parse_pypi.py
@@ -83,7 +83,10 @@ def get_pypi_metadata(package_name: str, parse_wheel=True) -> Optional[PypiData]
         if data.get("packagetype"):
             build_types[data.get("packagetype")] = data.get("url")
     if "bdist_wheel" not in build_types:
-        REPORTER.warn("No bdist_wheel available for PyPI release")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W019'>W019</a>: "
+            "No <pre>bdist_wheel</pre> available for PyPI release."
+        )
 
     # We cannot read 'entry_points' from PyPI JSON so must download the wheel file
     if not build_types.get("bdist_wheel") or not parse_wheel:
@@ -115,6 +118,10 @@ def get_pypi_metadata(package_name: str, parse_wheel=True) -> Optional[PypiData]
                         entry_points[key] = dict(value.items())
 
     except Exception as err:  # pylint: disable=broad-except
-        REPORTER.warn(f"Unable to read wheel file from PyPI release: {err}")
+        REPORTER.warn(
+            "<a href='https://github.com/aiidateam/aiida-registry#W020'>W020</a>: "
+            "Unable to read wheel file from PyPI release: "
+            f"<pre>{err}</pre>"
+        )
 
     return PypiData(metadata, aiida_version=aiida_version, entry_points=entry_points)

--- a/aiida_registry/parse_pypi.py
+++ b/aiida_registry/parse_pypi.py
@@ -85,7 +85,7 @@ def get_pypi_metadata(package_name: str, parse_wheel=True) -> Optional[PypiData]
     if "bdist_wheel" not in build_types:
         REPORTER.warn(
             "<a href='https://github.com/aiidateam/aiida-registry#W019'>W019</a>: "
-            "No <pre>bdist_wheel</pre> available for PyPI release."
+            "No <code>bdist_wheel</code> available for PyPI release."
         )
 
     # We cannot read 'entry_points' from PyPI JSON so must download the wheel file

--- a/aiida_registry/parse_pypi.py
+++ b/aiida_registry/parse_pypi.py
@@ -84,8 +84,8 @@ def get_pypi_metadata(package_name: str, parse_wheel=True) -> Optional[PypiData]
             build_types[data.get("packagetype")] = data.get("url")
     if "bdist_wheel" not in build_types:
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W019'>W019</a>: "
-            "No <code>bdist_wheel</code> available for PyPI release."
+            "No <code>bdist_wheel</code> available for PyPI release.",
+            check_id="W019",
         )
 
     # We cannot read 'entry_points' from PyPI JSON so must download the wheel file
@@ -119,9 +119,8 @@ def get_pypi_metadata(package_name: str, parse_wheel=True) -> Optional[PypiData]
 
     except Exception as err:  # pylint: disable=broad-except
         REPORTER.warn(
-            "<a href='https://github.com/aiidateam/aiida-registry#W020'>W020</a>: "
-            "Unable to read wheel file from PyPI release: "
-            f"<pre>{err}</pre>"
+            "Unable to read wheel file from PyPI release: " f"<pre>{err}</pre>",
+            check_id="W020",
         )
 
     return PypiData(metadata, aiida_version=aiida_version, entry_points=entry_points)

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -69,14 +69,14 @@ def supports_python_version(plugin_info):
     return False
 
 
-def handle_error(process_result, message):
+def handle_error(process_result, message, check_id=None):
     error_message = ""
 
     if process_result.exit_code != 0:
         error_message = process_result.output.decode("utf8")
 
         # the error_message is formatted as code block
-        REPORTER.error(f"{message}" f"<pre>{error_message}</pre>")
+        REPORTER.error(f"{message}" f"<pre>{error_message}</pre>", check_id=check_id)
         raise ValueError(f"{message}\n{error_message}")
 
     return error_message
@@ -107,10 +107,8 @@ def test_install_one_docker(container_image, plugin):
 
         error_message = handle_error(
             install_package,
-            (
-                "<a href='https://github.com/aiidateam/aiida-registry#E001'>E001</a>: "
-                f"Failed to install plugin {plugin['name']}"
-            ),
+            f"Failed to install plugin {plugin['name']}",
+            check_id="E001",
         )
 
         # Should make this depend on the AiiDA version inside the container,
@@ -129,10 +127,8 @@ def test_install_one_docker(container_image, plugin):
 
         error_message = handle_error(
             import_package,
-            (
-                "<a href='https://github.com/aiidateam/aiida-registry#E002'>E002</a>: "
-                f"Failed to import package {plugin['package_name']}"
-            ),
+            f"Failed to import package {plugin['package_name']}",
+            check_id="E002",
         )
         is_package_importable = True
 
@@ -145,10 +141,8 @@ def test_install_one_docker(container_image, plugin):
         )
         error_message = handle_error(
             extract_metadata,
-            (
-                "<a href='https://github.com/aiidateam/aiida-registry#E003'>E003</a>: "
-                f"Failed to fetch entry point metadata for package {plugin['package_name']}"
-            ),
+            f"Failed to fetch entry point metadata for package {plugin['package_name']}",
+            check_id="E003",
         )
 
         with open("result.json", "r", encoding="utf8") as handle:

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -76,7 +76,7 @@ def handle_error(process_result, message):
         error_message = process_result.output.decode("utf8")
 
         # the error_message is formatted as code block
-        REPORTER.error(f"{message}" "</br>" f"<pre>{error_message}</pre>")
+        REPORTER.error(f"{message}" f"<pre>{error_message}</pre>")
         raise ValueError(f"{message}\n{error_message}")
 
     return error_message

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -76,7 +76,7 @@ def handle_error(process_result, message):
         error_message = process_result.output.decode("utf8")
 
         # the error_message is formatted as code block
-        REPORTER.error(f"{message}</br><pre>{error_message}</pre>")
+        REPORTER.error(f"{message}" "</br>" f"<pre>{error_message}</pre>")
         raise ValueError(f"{message}\n{error_message}")
 
     return error_message
@@ -106,7 +106,11 @@ def test_install_one_docker(container_image, plugin):
         install_package = container.exec_run(f'pip install --pre {plugin["pip_url"]}')
 
         error_message = handle_error(
-            install_package, f"Failed to install plugin {plugin['name']}"
+            install_package,
+            (
+                "<a href='https://github.com/aiidateam/aiida-registry#E001'>E001</a>: "
+                f"Failed to install plugin {plugin['name']}"
+            ),
         )
 
         # Should make this depend on the AiiDA version inside the container,
@@ -124,7 +128,11 @@ def test_install_one_docker(container_image, plugin):
         )
 
         error_message = handle_error(
-            import_package, f"Failed to import package {plugin['package_name']}"
+            import_package,
+            (
+                "<a href='https://github.com/aiidateam/aiida-registry#E002'>E002</a>: "
+                f"Failed to import package {plugin['package_name']}"
+            ),
         )
         is_package_importable = True
 
@@ -137,7 +145,10 @@ def test_install_one_docker(container_image, plugin):
         )
         error_message = handle_error(
             extract_metadata,
-            f"Failed to fetch entry point metadata for package {plugin['package_name']}",
+            (
+                "<a href='https://github.com/aiidateam/aiida-registry#E003'>E003</a>: "
+                f"Failed to fetch entry point metadata for package {plugin['package_name']}"
+            ),
         )
 
         with open("result.json", "r", encoding="utf8") as handle:

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -241,7 +241,7 @@ def test_install_all(container_image):
     # the data object there for MUST NOT be called in the loop above
     data["plugins"] = add_registry_checks(data["plugins"])
 
-    print("Dumping plugins.json")
+    print("Dumping plugins_metadata.json")
     with open(PLUGINS_METADATA, "w", encoding="utf8") as handle:
         json.dump(data, handle, indent=2)
     print(json.dumps(data, indent=4))

--- a/aiida_registry/utils.py
+++ b/aiida_registry/utils.py
@@ -23,12 +23,11 @@ def fetch_file(file_url: str, warn=True) -> str:
     except Exception:  # pylint: disable=broad-except
         if warn:
             REPORTER.error(
-                "<a href='https://github.com/aiidateam/aiida-registry#E004'>E004</a>"
+                "<a href='https://github.com/aiidateam/aiida-registry#E004'>E004</a>: "
+                f"Unable to retrieve plugin metadata, retrieve plugin info from {file_url} failed."
+                "</br>"
+                f"<pre>{traceback.format_exc()}</pre>"
             )
-            REPORTER.error("Unable to retrieve plugin metadata")
-            REPORTER.error(f"Retrive plugin info from {file_url}.")
-            REPORTER.error(f"<pre>{traceback.format_exc()}</pre>")
-
             REPORTER.debug(traceback.format_exc())
         return None
     return response.content.decode(response.encoding or "utf8")

--- a/aiida_registry/utils.py
+++ b/aiida_registry/utils.py
@@ -23,9 +23,9 @@ def fetch_file(file_url: str, warn=True) -> str:
     except Exception:  # pylint: disable=broad-except
         if warn:
             REPORTER.error(
-                "<a href='https://github.com/aiidateam/aiida-registry#E004'>E004</a>: "
                 f"Unable to retrieve plugin metadata, retrieve plugin info from '{file_url}' failed."
-                f"<pre>{traceback.format_exc()}</pre>"
+                f"<pre>{traceback.format_exc()}</pre>",
+                check_id="E004",
             )
             REPORTER.debug(traceback.format_exc())
         return None

--- a/aiida_registry/utils.py
+++ b/aiida_registry/utils.py
@@ -24,8 +24,7 @@ def fetch_file(file_url: str, warn=True) -> str:
         if warn:
             REPORTER.error(
                 "<a href='https://github.com/aiidateam/aiida-registry#E004'>E004</a>: "
-                f"Unable to retrieve plugin metadata, retrieve plugin info from {file_url} failed."
-                "</br>"
+                f"Unable to retrieve plugin metadata, retrieve plugin info from '{file_url}' failed."
                 f"<pre>{traceback.format_exc()}</pre>"
             )
             REPORTER.debug(traceback.format_exc())

--- a/aiida_registry/utils.py
+++ b/aiida_registry/utils.py
@@ -14,7 +14,7 @@ if os.environ.get("CACHE_REQUESTS"):
     requests_cache.install_cache("demo_cache", expire_after=60 * 60 * 24)
 
 
-def fetch_file(file_url: str, file_type: str = "plugin info", warn=True) -> str:
+def fetch_file(file_url: str, warn=True) -> str:
     """Fetch plugin info from a URL to a file."""
     try:
         response = requests.get(file_url, timeout=60)
@@ -23,9 +23,12 @@ def fetch_file(file_url: str, file_type: str = "plugin info", warn=True) -> str:
     except Exception:  # pylint: disable=broad-except
         if warn:
             REPORTER.error(
-                f"Unable to retrieve {file_type} from: {file_url}."
-                "Please check the URL of your plugin in the registry yaml."
+                "<a href='https://github.com/aiidateam/aiida-registry#E004'>E004</a>"
             )
+            REPORTER.error("Unable to retrieve plugin metadata")
+            REPORTER.error(f"Retrive plugin info from {file_url}.")
+            REPORTER.error(f"<pre>{traceback.format_exc()}</pre>")
+
             REPORTER.debug(traceback.format_exc())
         return None
     return response.content.decode(response.encoding or "utf8")


### PR DESCRIPTION
In front of every warning and error check message, the link is redirected to the README with the corresponding code number which gives the hint for fixing the issue of the plugin registry.