### PR TITLE
Fix multiple author email-to link

### DIFF
--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -56,7 +56,7 @@ runs:
           env:
             GITHUB_TOKEN: ${{ inputs.gh_token }}
           run: |
-            aiida-registry fetch
+            aiida-registry fetch aiida-kkr aiida-pseudo
           shell: bash
 
         - name: Check installation of plugins

--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -56,7 +56,7 @@ runs:
           env:
             GITHUB_TOKEN: ${{ inputs.gh_token }}
           run: |
-            aiida-registry fetch aiida-kkr aiida-pseudo
+            aiida-registry fetch
           shell: bash
 
         - name: Check installation of plugins

--- a/aiida-registry-app/src/Components/Details.jsx
+++ b/aiida-registry-app/src/Components/Details.jsx
@@ -105,10 +105,13 @@ function Details({pluginKey}) {
             </p>
             {value.metadata.author_email && (
               <p>
-                <strong>Contact</strong>:{" "}
-                <a href={`mailto:${value.metadata.author_email}`}>
-                  {value.metadata.author_email}
-                </a>
+                <strong>Contact</strong>:
+                  {value.metadata.author_email.split(',').map(email => (
+                    <span key={email}>
+                      <a href={`mailto:${email.trim()}`}>{email.trim()}</a>
+                      {', '}
+                    </span>
+                  ))}
               </p>
             )}
             <p>

--- a/aiida-registry-app/src/Components/Details.jsx
+++ b/aiida-registry-app/src/Components/Details.jsx
@@ -100,9 +100,11 @@ function Details({pluginKey}) {
       <h2 id='detailed.information'>Detailed information</h2>
         {Object.keys(value.metadata).length !== 0 ? (
           <>
-            <p>
-              <strong>Author(s)</strong>: {value.metadata.author}
-            </p>
+            {value.metadata.author && (
+              <p>
+                <strong>Author(s)</strong>: {value.metadata.author}
+              </p>
+            )}
             {value.metadata.author_email && (
               <p>
                 <strong>Contact</strong>:


### PR DESCRIPTION
Solve two problems:
1. In `aiida-kkr` the authors emails are stick to one hyperlink.
2. In `aiida-pseudo` and more the author field is empty.