### PR TITLE
Fix the duplicate error message issue

### DIFF
--- a/aiida_registry/__init__.py
+++ b/aiida_registry/__init__.py
@@ -155,10 +155,15 @@ class Reporter:
     def reset(self):
         """Reset the warnings list."""
         self.warnings = []
+        self.errors = []
 
     def set_plugin_name(self, name):
         """Set the plugin name."""
         self.plugin_name = name
+        self.reset()
+
+        self.plugins_warnings[self.plugin_name] = []
+        self.plugins_errors[self.plugin_name] = []
 
     def warn(self, string):
         """Write to stdout and log.
@@ -170,10 +175,7 @@ class Reporter:
         # e.g., for display as part of an issue comment.
         if self.plugin_name:
             self.warnings.append(f"{message} [{self.plugin_name}]")
-            try:
-                self.plugins_warnings[self.plugin_name].append(string)
-            except KeyError:
-                self.plugins_warnings[self.plugin_name] = [string]
+            self.plugins_warnings[self.plugin_name].append(string)
         else:
             self.warnings.append(message)
         print(message)
@@ -183,10 +185,7 @@ class Reporter:
         message = f"  > ERROR! {string}"
         if self.plugin_name:
             self.errors.append(f"{message} [{self.plugin_name}]")
-            try:
-                self.plugins_errors[self.plugin_name].append(string)
-            except KeyError:
-                self.plugins_errors[self.plugin_name] = [string]
+            self.plugins_errors[self.plugin_name].append(string)
         else:
             self.errors.append(message)
         print(message)

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -223,7 +223,10 @@ def test_install_all(container_image):
             except KeyError:
                 continue
 
-        data["plugins"] = add_registry_checks(data["plugins"])
+    # Add warnings and errors to the data object
+    # This will loop over the plugins and add the warnings/errors to
+    # the data object there for MUST NOT be called in the loop above
+    data["plugins"] = add_registry_checks(data["plugins"])
 
     print("Dumping plugins.json")
     with open(PLUGINS_METADATA, "w", encoding="utf8") as handle:


### PR DESCRIPTION
Narrow down and find the catch is from I call many times of `add_registry_checks` method inside the loop over all plugins. 