### PR TITLE
Seperate the dev CI tests to run for dev changes

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+# For development, use the following instead:
+on: [pull_request]
+
+
+# https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+    # only cancel in-progress jobs or runs for the current workflow - matches against branch & tags
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+  test-utils:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo ⚡️
+      uses: actions/checkout@v4
+    - name: Create dev environment
+      uses: ./.github/actions/create-dev-env
+    - name: Run tests
+      run: pytest tests/
+
+  test-webpage-build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    timeout-minutes: 30
+    steps:
+    # This is a CI job that checks if the webpage can be built
+    # We use the plugins metadata from caching since we don't want to
+    # fetch it twice and it is not essential for this job to have
+    # the latest generated metadata
+    - name: Checkout Repo ⚡️
+      uses: actions/checkout@v4
+
+    - name: Create dev environment
+      uses: ./.github/actions/create-dev-env
+
+    - name: Generate metadata
+      uses: ./.github/actions/generate-metadata
+      with:
+        gh_token: ${{ secrets.GITHUB_TOKEN }}
+        cache: true
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+    - name: Install npm dependencies and build
+      run: |
+        npm install
+        npm run build
+      working-directory: ./aiida-registry-app

--- a/.github/workflows/plugin-ci.yml
+++ b/.github/workflows/plugin-ci.yml
@@ -32,21 +32,6 @@ jobs:
       - uses: suzuki-shunsuke/get-pr-action@v0.1.0
         id: pr
 
-  pre-commit:
-    runs-on: ubuntu-latest
-    needs:
-      - get-pr
-    steps:
-    - name: Checkout Repo ⚡️
-      uses: actions/checkout@v4
-      with:
-        ref: ${{needs.get-pr.outputs.merge_commit_sha}}
-    - name: Create dev environment
-      uses: ./.github/actions/create-dev-env
-    - name: Run pre-commit
-      run:
-        pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
-
   test-utils:
     runs-on: ubuntu-latest
     needs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,21 +11,10 @@ repos:
     - id: trailing-whitespace
     - id: check-json
 
-- repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.2.2
   hooks:
-  - id: isort
-    args: ["--profile", "black", "--filter-files"]
-
-- repo: https://github.com/psf/black
-  rev: 23.1.0
-  hooks:
-    - id: black
-
-- repo: local
-  hooks:
-    - id: pylint
-      name: pylint
-      entry: pylint
-      types: [python]
-      language: system
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix, --show-fixes]
+      - id: ruff-format

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,0 @@
-[FORMAT]
-max-line-length=120

--- a/aiida_registry/fetch_metadata.py
+++ b/aiida_registry/fetch_metadata.py
@@ -134,9 +134,7 @@ def get_git_commits_count(repo_name):
     return int(commits_count)
 
 
-def complete_plugin_data(
-    plugin_data: dict, fetch_pypi=True, fetch_pypi_wheel=True
-):  # pylint: disable=too-many-branches,too-many-statements
+def complete_plugin_data(plugin_data: dict, fetch_pypi=True, fetch_pypi_wheel=True):  # pylint: disable=too-many-branches,too-many-statements
     """Update plugin data dictionary.
 
      * add metadata, aiida_version and entrypoints from plugin_info

--- a/aiida_registry/parse_build_file.py
+++ b/aiida_registry/parse_build_file.py
@@ -261,9 +261,9 @@ def parse_setup_cfg(content: str, ep_only=False) -> SourceData:
     }
     if config.has_option("metadata", "classifiers"):
         infos["metadata"]["classifiers"] = [
-            l.strip()
-            for l in config.get("metadata", "classifiers").splitlines()
-            if l.strip() and not l.strip().startswith("#")
+            line.strip()
+            for line in config.get("metadata", "classifiers").splitlines()
+            if line.strip() and not line.strip().startswith("#")
         ]
 
     return SourceData(**infos)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
     "markupsafe~=2.0.1",
     # dev dependencies
     "pre-commit~=2.2",
-    "pylint~=2.16.1",
     "pytest~=6.2.2",
     "pytest-regressions~=2.5.0",
 ]


### PR DESCRIPTION
Fixes https://github.com/aiidateam/aiida-registry/pull/306

The CI action not triggered because the changes are made not from `plugins.yaml` file, thus not trigger the CI. 
The following restriction is set to only trigger the preview CI to prevent the malicious code inject to CI actions. 
https://github.com/aiidateam/aiida-registry/blob/c306d6a7cb85ef12eba51a24d4d3f21805e70b3d/.github/workflows/ci.yml#L10-L11

In this PR, I separate the actions that test changes on other development changes to other CI which will not term out to be a preview from our official aiida official domain. Besides, I remove the pre-commit action and make it triggered from GHA integration.