### PR TITLE
Update test_install.py install stable version

### DIFF
--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -120,7 +120,7 @@ def test_install_one_docker(container_image, plugin):
             user=user,
         )
         install_package = container.exec_run(
-            f'pip install --constraint /tmp/pip-constraint.txt --pre {plugin["pip_url"]}',
+            f'pip install --constraint /tmp/pip-constraint.txt {plugin["pip_url"]}',
             user=user,
         )
 


### PR DESCRIPTION
From the team, we agree on installing stable released version instead of pre-release version which may include bugs and not the plugin developers intend to show to the community.