### PR TITLE
Add load_profile to entrypoints analyse

### DIFF
--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -110,4 +110,3 @@ jobs:
         action: auto
         custom-url:
         token: ${{ secrets.BOT_COMMENT_TOKEN }} # use aiida-bot token to deploy the preview
-

--- a/.github/workflows/dev-ci.yml
+++ b/.github/workflows/dev-ci.yml
@@ -11,6 +11,15 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+  get-pr:
+    # https://dev.to/suzukishunsuke/secure-github-actions-by-pullrequesttarget-641
+    outputs:
+        merge_commit_sha: ${{steps.pr.outputs.merge_commit_sha}}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: suzuki-shunsuke/get-pr-action@v0.1.0
+        id: pr
+
   test-utils:
     runs-on: ubuntu-latest
     steps:
@@ -51,3 +60,54 @@ jobs:
         npm install
         npm run build
       working-directory: ./aiida-registry-app
+
+  preview:
+    # This job is triggered by from PR from the aiida-registry repo, the developer of aiida-registry need to see the preview page of the PR
+    needs: [test-webpage-build, get-pr]
+    if: github.repository == 'aiidateam/aiida-registry'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    timeout-minutes: 180
+    env:
+      COMMIT_AUTHOR: Deploy Action
+      COMMIT_AUTHOR_EMAIL: action@github.com
+      VITE_PR_PREVIEW_PATH: "/aiida-registry/pr-preview/pr-${{ github.event.number }}/"
+
+    steps:
+    - name: Checkout Repo ⚡️
+      uses: actions/checkout@v4
+      with:
+        ref: ${{needs.get-pr.outputs.merge_commit_sha}}
+    - name: Create dev environment
+      uses: ./.github/actions/create-dev-env
+
+    - name: Generate metadata
+      uses: ./.github/actions/generate-metadata
+      with:
+        gh_token: ${{ secrets.GITHUB_TOKEN }}
+        cache: false
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '18.x'
+    - name: Install npm dependencies and build
+      run: |
+        echo $VITE_PR_PREVIEW_PATH
+        npm install
+        npm run build
+      working-directory: ./aiida-registry-app
+
+    - name: Add plugins file to the build folder
+      run: cp plugins_metadata.json aiida-registry-app/dist/
+
+    - name: Deploy preview
+      uses: rossjrw/pr-preview-action@v1
+      with:
+        source-dir: ./aiida-registry-app/dist
+        preview-branch: gh-pages
+        umbrella-dir: pr-preview
+        action: auto
+        custom-url:
+        token: ${{ secrets.BOT_COMMENT_TOKEN }} # use aiida-bot token to deploy the preview
+

--- a/bin/analyze_entrypoints.py
+++ b/bin/analyze_entrypoints.py
@@ -15,6 +15,9 @@ from dataclasses import asdict, dataclass
 from typing import Dict, List
 
 import click
+import aiida
+
+aiida.load_profile()
 
 ENTRY_POINT_GROUPS = [
     "aiida.calculations",


### PR DESCRIPTION
`aiida-aimall` show an error that actually can be avoid from `analyse_entrypoint.py`. It raises because it use `default=Int(1)` instead of `default=lambda: Int(1)` that is better in practice (see https://aiida.readthedocs.io/projects/aiida-core/en/latest/topics/processes/usage.html#validation-and-defaults). The point is we should not force developer to do this and the `default=Int(1)` is acceptable. 

So In this PR I just add `aiida.load_profile()` since the profile is exist in the aiida-core-with-servecs image. In the future, we can considered to use the light profile for entry_point analysis.