### PR TITLE
add aiida-icon plugin to the list

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -561,3 +561,9 @@ aiida-inq:
   plugin_info: https://github.com/LLNL/aiida-inq/blob/main/pyproject.toml
   code_home: https://github.com/LLNL/aiida-inq
   pip_url: aiida-inq
+aiida-icon:
+  entry_point_prefix: icon
+  pip_url: aiida-icon
+  documentation_url: https://aiida-icon.github.io/aiida-icon/
+  code_home: https://github.com/aiida-icon/aiida-icon
+  plugin_info: https://raw.githubusercontent.com/aiida-icon/aiida-icon/main/pyproject.toml


### PR DESCRIPTION
Adding `aiida-icon`, the (first?) plugin for the weather and climate field. It's being developed at CSCS primarily for C2SM and EXCLAIM, in close cooperation with AiiDA-Team.