### PR TITLE
Update plugin name for aiida-quantumespresso-hp

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -335,11 +335,11 @@ aiida-quantumespresso:
   entry_point_prefix: quantumespresso
   pip_url: aiida-quantumespresso
   plugin_info: https://raw.github.com/aiidateam/aiida-quantumespresso/master/setup.json
-aiida-quantumespresso-hp:
-  code_home: https://github.com/aiidateam/aiida-quantumespresso-hp
+aiida-hubbard:
+  code_home: https://github.com/aiidateam/aiida-hubbard
   entry_point_prefix: quantumespresso.hp
-  pip_url: git+https://github.com/aiidateam/aiida-quantumespresso-hp
-  plugin_info: https://raw.githubusercontent.com/aiidateam/aiida-quantumespresso-hp/master/pyproject.toml
+  pip_url: git+https://github.com/aiidateam/aiida-hubbard
+  plugin_info: https://raw.githubusercontent.com/aiidateam/aiida-hubbard/master/pyproject.toml
 aiida-raspa:
   code_home: https://github.com/yakutovicha/aiida-raspa
   entry_point_prefix: raspa

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -338,8 +338,8 @@ aiida-quantumespresso:
 aiida-hubbard:
   code_home: https://github.com/aiidateam/aiida-hubbard
   entry_point_prefix: quantumespresso.hp
-  pip_url: git+https://github.com/aiidateam/aiida-hubbard
-  plugin_info: https://raw.githubusercontent.com/aiidateam/aiida-hubbard/master/pyproject.toml
+  pip_url: aiida-hubbard
+  plugin_info: https://raw.github.com/aiidateam/aiida-hubbard/master/pyproject.toml
 aiida-raspa:
   code_home: https://github.com/yakutovicha/aiida-raspa
   entry_point_prefix: raspa


### PR DESCRIPTION
We changed the name of the `aiida-quantumespresso-hp` plugin to `aiida-hubbard`. The entry point is still fixed to `quantumespresso.hp` as this package provides the plugin for the HP code of Quantum ESPRESSO. 