### PR TITLE
Updating code to check for exit_code

### DIFF
--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -156,11 +156,12 @@ def test_install_one_docker(container_image, plugin):
             cmd="python ./bin/analyze_entrypoints.py -o result.json",
             user=user,
         )
-        error_message = handle_error(
-            extract_metadata,
-            f"Failed to fetch entry point metadata for package {plugin['package_name']}",
-            check_id="E003",
-        )
+        if extract_metadata.exit_code != 0:
+            error_message = handle_error(
+                extract_metadata.output.decode(),
+                f"Failed to fetch entry point metadata for package {plugin['package_name']}",
+                check_id="E003",
+            )
 
         with open("result.json", "r", encoding="utf8") as handle:
             process_metadata = json.load(handle)


### PR DESCRIPTION
issue #352 

Instead of passing the entire `exec_result` object, explicitly check for `exit_code`.

- Checks if `exit_code` is nonzero. if so, it means failure.
- Ensure that `exact_metadata.output` is properly passed to `handle_error`.
- Convert error output from bytes to string (`.decode()`) , so it's readable.