### PR TITLE
✨ Add aiida-wannierjl

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -446,6 +446,13 @@ aiida-wannier90-workflows:
   entry_point_prefix: wannier90_workflows
   pip_url: aiida-wannier90-workflows
   plugin_info: https://raw.github.com/aiidateam/aiida-wannier90-workflows/master/setup.json
+aiida-wannierjl:
+  code_home: https://github.com/elinscott/aiida-wannierjl
+  development_status: alpha
+  documentation_url: https://aiida-wannierjl.readthedocs.io/
+  entry_point_prefix: wannierjl
+  pip_url: git+https://github.com/elinscott/aiida-wannierjl
+  plugin_info: https://raw.githubusercontent.com/elinscott/aiida-wannierjl/main/pyproject.toml
 aiida-wien2k:
   code_home: https://github.com/rubel75/aiida-wien2k
   entry_point_prefix: wien2k

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -450,7 +450,7 @@ aiida-wannierjl:
   code_home: https://github.com/elinscott/aiida-wannierjl
   documentation_url: https://aiida-wannierjl.readthedocs.io/
   entry_point_prefix: wannierjl
-  pip_url: git+https://github.com/elinscott/aiida-wannierjl
+  pip_url: aiida-wannierjl
   plugin_info: https://raw.githubusercontent.com/elinscott/aiida-wannierjl/main/pyproject.toml
 aiida-wien2k:
   code_home: https://github.com/rubel75/aiida-wien2k

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -448,7 +448,6 @@ aiida-wannier90-workflows:
   plugin_info: https://raw.github.com/aiidateam/aiida-wannier90-workflows/master/setup.json
 aiida-wannierjl:
   code_home: https://github.com/elinscott/aiida-wannierjl
-  development_status: alpha
   documentation_url: https://aiida-wannierjl.readthedocs.io/
   entry_point_prefix: wannierjl
   pip_url: git+https://github.com/elinscott/aiida-wannierjl


### PR DESCRIPTION
Adds `aiida-wannierjl`, an AiiDA plugin wrapping [Wannier.jl](https://github.com/qiaojunfeng/Wannier.jl): CalcJobs for Wannier.jl's manifold-splitting (`mrwf`) method and its cubic-neighbour fallback, plus an aiida-workgraph workflow chaining them from a completed wannier90 run.

- Source: https://github.com/elinscott/aiida-wannierjl
- PyPI: https://pypi.org/project/aiida-wannierjl/ (v0.1.0)
- Docs: https://aiida-wannierjl.readthedocs.io/