### PR TITLE
Submission of the aiida-dftbplus to plugin registry

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -609,3 +609,9 @@ aiida-octopus:
   entry_point_prefix: octopus
   pip_url: aiida-octopus
   plugin_info: https://gitlab.com/octopus-code/aiida-octopus/-/raw/main/pyproject.toml
+aiida-dftbplus:
+  code_home: https://github.com/Quantum-ARISE-Acad/aiida-dftbplus
+  documentation_url: https://shrill-morning-67e8.sitouamu510.workers.dev/
+  entry_point_prefix: dftbplus
+  pip_url: aiida-dftbplus
+  plugin_info: https://raw.githubusercontent.com/Quantum-ARISE-Acad/aiida-dftbplus/main/pyproject.toml

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -613,5 +613,5 @@ aiida-dftbplus:
   code_home: https://github.com/Quantum-ARISE-Acad/aiida-dftbplus
   documentation_url: https://shrill-morning-67e8.sitouamu510.workers.dev/
   entry_point_prefix: dftbplus
-  pip_url: aiida-dftbplus
+  pip_url: https://pypi.org/project/aiida-dftbplus/
   plugin_info: https://raw.githubusercontent.com/Quantum-ARISE-Acad/aiida-dftbplus/main/pyproject.toml


### PR DESCRIPTION
Registers `aiida-dftbplus`: calculations, data types, and parsers interfacing AiiDA with the [DFTB+](https://dftbplus.org) simulation engine.

DFTB+ is a widely used density-functional tight-binding code — two to three orders of magnitude cheaper than DFT — which makes it a natural fit for the high-throughput screening and large-system work AiiDA is built for. Until now there was no AiiDA interface for it, so DFTB+ runs in AiiDA-based workflows had to be driven by hand, outside the provenance graph.

The plugin wraps a DFTB+ execution as a `CalcJob`: it generates `dftb_in.hsd`, stages the Slater–Koster parameter files, submits through AiiDA's scheduler and transport layers, retrieves the outputs, and parses energies, Fermi level, SCC status, and forces into a queryable `Dict`. The DFTB+ input is stored as a nested dictionary rather than an opaque text file, so every setting of every calculation stays searchable in the database.

| Metadata | Details |
|---|---|
| **Entry point prefix** | `dftbplus` (calculations, parsers, data, cmdline.data) |
| **PyPI** | [`aiida-dftbplus`](https://pypi.org/project/aiida-dftbplus/) (v0.1.0, wheel + sdist) |
| **Requirements** | `aiida-core>=2.0` |
| **License** | MIT |
| **Status** | Alpha — single calculation in/out supported; workflows in active development |

---

### Automated Verification & CI
CI pipeline executes:
* Linting & static security analysis (SAST)
* Unit & integration test suite (Python 3.9–3.12)
* Live integration run against `dftbplus` binaries from `conda-forge`
* Automated documentation builds