### PR TITLE
submission of aiida-dftbplus plugin to aiida  registry

### DIFF
--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -16,17 +16,11 @@ from . import PLUGINS_METADATA, REPORTER
 
 # Where to mount the workdir inside the Docker container
 _DOCKER_WORKDIR = "/tmp/scripts"
-<<<<<<< HEAD
-# Where the entry-point report is written *inside* the container. It must not
-# be on the bind mount: that is the host checkout, owned by a different uid.
-_CONTAINER_RESULT = "/tmp/result.json"
-=======
 # Where `analyze_entrypoints.py` writes its output inside the container. This must be
 # outside `_DOCKER_WORKDIR`: that is a bind mount of the host checkout, owned by the
 # host user (uid 1001 on GitHub runners), while the container runs as `aiida` (uid
 # 1000), so the container cannot create files in it.
 _DOCKER_RESULT_PATH = "/tmp/result.json"
->>>>>>> upstream/master
 ENTRY_POINT_GROUPS = [
     "aiida.calculations",
     "aiida.workflows",
@@ -162,19 +156,9 @@ def test_install_one_docker(container_image, plugin):
         print(
             "   - Extracting entry point metadata for {}".format(plugin["package_name"])
         )
-        # Write the report to a container-local path, not to `result.json` in
-        # the bind-mounted workdir. That mount is the runner's checkout, owned
-        # by the host user; the container's non-root user cannot create files
-        # in it and the script died with `PermissionError: [Errno 13]`. Reading
-        # the report back over `cat` also removes the stale-file hazard of the
-        # previous plugin's `result.json` being picked up when a write fails.
         extract_metadata = container.exec_run(
             workdir=_DOCKER_WORKDIR,
-<<<<<<< HEAD
-            cmd=f"python ./bin/analyze_entrypoints.py -o {_CONTAINER_RESULT}",
-=======
             cmd=f"python ./bin/analyze_entrypoints.py -o {_DOCKER_RESULT_PATH}",
->>>>>>> upstream/master
             user=user,
         )
         error_message = handle_error(
@@ -183,14 +167,7 @@ def test_install_one_docker(container_image, plugin):
             check_id="E003",
         )
 
-<<<<<<< HEAD
-        read_metadata = container.exec_run(
-            cmd=f"cat {_CONTAINER_RESULT}",
-            user=user,
-        )
-=======
         read_metadata = container.exec_run(f"cat {_DOCKER_RESULT_PATH}", user=user)
->>>>>>> upstream/master
         error_message = handle_error(
             read_metadata,
             f"Failed to read entry point metadata for package {plugin['package_name']}",

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -16,6 +16,9 @@ from . import PLUGINS_METADATA, REPORTER
 
 # Where to mount the workdir inside the Docker container
 _DOCKER_WORKDIR = "/tmp/scripts"
+# Where the entry-point report is written *inside* the container. It must not
+# be on the bind mount: that is the host checkout, owned by a different uid.
+_CONTAINER_RESULT = "/tmp/result.json"
 ENTRY_POINT_GROUPS = [
     "aiida.calculations",
     "aiida.workflows",
@@ -151,9 +154,15 @@ def test_install_one_docker(container_image, plugin):
         print(
             "   - Extracting entry point metadata for {}".format(plugin["package_name"])
         )
+        # Write the report to a container-local path, not to `result.json` in
+        # the bind-mounted workdir. That mount is the runner's checkout, owned
+        # by the host user; the container's non-root user cannot create files
+        # in it and the script died with `PermissionError: [Errno 13]`. Reading
+        # the report back over `cat` also removes the stale-file hazard of the
+        # previous plugin's `result.json` being picked up when a write fails.
         extract_metadata = container.exec_run(
             workdir=_DOCKER_WORKDIR,
-            cmd="python ./bin/analyze_entrypoints.py -o result.json",
+            cmd=f"python ./bin/analyze_entrypoints.py -o {_CONTAINER_RESULT}",
             user=user,
         )
         error_message = handle_error(
@@ -162,8 +171,16 @@ def test_install_one_docker(container_image, plugin):
             check_id="E003",
         )
 
-        with open("result.json", "r", encoding="utf8") as handle:
-            process_metadata = json.load(handle)
+        read_metadata = container.exec_run(
+            cmd=f"cat {_CONTAINER_RESULT}",
+            user=user,
+        )
+        error_message = handle_error(
+            read_metadata,
+            f"Failed to read entry point metadata for package {plugin['package_name']}",
+            check_id="E003",
+        )
+        process_metadata = json.loads(read_metadata.output.decode("utf8"))
 
         process_metadata = filter_entry_points(process_metadata, plugin["entry_points"])
 

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -611,7 +611,7 @@ aiida-octopus:
   plugin_info: https://gitlab.com/octopus-code/aiida-octopus/-/raw/main/pyproject.toml
 aiida-dftbplus:
   code_home: https://github.com/Quantum-ARISE-Acad/aiida-dftbplus
-  documentation_url: https://shrill-morning-67e8.sitouamu510.workers.dev/
+  documentation_url: https://aiida-dftbplus.readthedocs.io/
   entry_point_prefix: dftbplus
   pip_url: aiida-dftbplus
   plugin_info: https://raw.githubusercontent.com/Quantum-ARISE-Acad/aiida-dftbplus/main/pyproject.toml

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -609,3 +609,9 @@ aiida-octopus:
   entry_point_prefix: octopus
   pip_url: aiida-octopus
   plugin_info: https://gitlab.com/octopus-code/aiida-octopus/-/raw/main/pyproject.toml
+aiida-dftbplus:
+  code_home: https://github.com/Quantum-ARISE-Acad/aiida-dftbplus
+  documentation_url: https://shrill-morning-67e8.sitouamu510.workers.dev/
+  entry_point_prefix: dftbplus
+  pip_url: aiida-dftbplus
+  plugin_info: https://raw.githubusercontent.com/Quantum-ARISE-Acad/aiida-dftbplus/main/pyproject.toml


### PR DESCRIPTION
Registers `aiida-dftbplus`: calculations, data types, and parsers interfacing AiiDA with the [DFTB+](https://dftbplus.org) simulation engine.

DFTB+ is a widely used density-functional tight-binding code — two to three orders of magnitude cheaper than DFT — which makes it a natural fit for the high-throughput screening and large-system work AiiDA is built for. Until now there was no AiiDA interface for it, so DFTB+ runs in AiiDA-based workflows had to be driven by hand, outside the provenance graph.

The plugin wraps a DFTB+ execution as a `CalcJob`: it generates `dftb_in.hsd`, stages the Slater–Koster parameter files, submits through AiiDA's scheduler and transport layers, retrieves the outputs, and parses energies, Fermi level, SCC status, and forces into a queryable `Dict`. The DFTB+ input is stored as a nested dictionary rather than an opaque text file, so every setting of every calculation stays searchable in the database.

| Metadata | Details |
|---|---|
| **Entry point prefix** | `dftbplus` (calculations, parsers, data, cmdline.data) |
| **PyPI** | [`aiida-dftbplus`](https://pypi.org/project/aiida-dftbplus/) (v0.1.0, wheel + sdist) |
| **Requirements** | `aiida-core>=2.0` |
| **License** | MIT |
| **Status** | Alpha — single calculation in/out supported; workflows in active development |

---

### Automated Verification & CI
CI pipeline executes:
* Linting & static security analysis (SAST)
* Unit & integration test suite (Python 3.9–3.12)
* Live integration run against `dftbplus` binaries from `conda-forge`
* Automated documentation builds