### PR TITLE
🐛 `test_install`: keep result.json off bind mount

### DIFF
--- a/.github/actions/generate-metadata/action.yml
+++ b/.github/actions/generate-metadata/action.yml
@@ -62,8 +62,6 @@ runs:
         - name: Check installation of plugins
           if: ${{ inputs.cache == 'false' }}
           # Attach plugin installation information to the metadata, e.g. if the plugin can be installed or not
-          # Need to make the _DOCKER_WORKDIR writable by (o)thers since the new docker stack has default aiida as system user rather than root.
           run: |
-            umask 000 && chmod +w ../aiida-registry
             aiida-registry test-install
           shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ logs
 
 # data genarated
 plugins_metadata.json
-result.json
 
 # python
 build/

--- a/aiida_registry/test_install.py
+++ b/aiida_registry/test_install.py
@@ -16,6 +16,11 @@ from . import PLUGINS_METADATA, REPORTER
 
 # Where to mount the workdir inside the Docker container
 _DOCKER_WORKDIR = "/tmp/scripts"
+# Where `analyze_entrypoints.py` writes its output inside the container. This must be
+# outside `_DOCKER_WORKDIR`: that is a bind mount of the host checkout, owned by the
+# host user (uid 1001 on GitHub runners), while the container runs as `aiida` (uid
+# 1000), so the container cannot create files in it.
+_DOCKER_RESULT_PATH = "/tmp/result.json"
 ENTRY_POINT_GROUPS = [
     "aiida.calculations",
     "aiida.workflows",
@@ -99,7 +104,7 @@ def test_install_one_docker(container_image, plugin):
     container = client.containers.run(
         container_image,
         detach=True,
-        volumes={os.getcwd(): {"bind": _DOCKER_WORKDIR, "mode": "rw"}},
+        volumes={os.getcwd(): {"bind": _DOCKER_WORKDIR, "mode": "ro"}},
     )
 
     user = container.exec_run("whoami").output.decode("utf8").strip()
@@ -153,7 +158,7 @@ def test_install_one_docker(container_image, plugin):
         )
         extract_metadata = container.exec_run(
             workdir=_DOCKER_WORKDIR,
-            cmd="python ./bin/analyze_entrypoints.py -o result.json",
+            cmd=f"python ./bin/analyze_entrypoints.py -o {_DOCKER_RESULT_PATH}",
             user=user,
         )
         error_message = handle_error(
@@ -162,8 +167,13 @@ def test_install_one_docker(container_image, plugin):
             check_id="E003",
         )
 
-        with open("result.json", "r", encoding="utf8") as handle:
-            process_metadata = json.load(handle)
+        read_metadata = container.exec_run(f"cat {_DOCKER_RESULT_PATH}", user=user)
+        error_message = handle_error(
+            read_metadata,
+            f"Failed to read entry point metadata for package {plugin['package_name']}",
+            check_id="E003",
+        )
+        process_metadata = json.loads(read_metadata.output.decode("utf8"))
 
         process_metadata = filter_entry_points(process_metadata, plugin["entry_points"])
 


### PR DESCRIPTION
Plugin submissions are currently going red with `E003: Failed to fetch entry point metadata`, even when the plugin installs and imports perfectly well. Visible right now on [#373](https://github.com/aiidateam/aiida-registry/pull/373) and [#375](https://github.com/aiidateam/aiida-registry/pull/375).

The cause is a uid mismatch across the bind mount in `aiida_registry/test_install.py`:

- The host checkout is mounted read-write at `/tmp/scripts` in the container, and `analyze_entrypoints.py` is told to write `result.json` into it.
- On GitHub runners that directory is owned by uid 1001 (`runner`), while `ghcr.io/aiidateam/aiida-core-with-services` runs as `aiida`, uid 1000, gid 100.
- So the write dies with `PermissionError: [Errno 13] Permission denied: 'result.json'`, `handle_error` turns that into E003, and the check fails.

The nightly `webpage` workflow does not hit this, because `generate-metadata` makes the checkout world-writable first (`umask 000 && chmod +w ../aiida-registry`). The new PR plugin checks call `aiida-registry test-install` directly, without that step, which is why the failure only shows up on pull requests.

Rather than copy the `chmod` into the second caller, this writes the file to `/tmp/result.json` inside the container and reads it back over `cat`, so the metadata never travels through the mount at all. The mount becomes read-only, since nothing needs to write to it any more, and the `umask`/`chmod` line in `generate-metadata` goes away with it, along with the now-dead `.gitignore` entry for `result.json`.

Verified locally against `ghcr.io/aiidateam/aiida-core-with-services:latest` with `aiida-registry test-install` on real plugin entries: E003 before, and after the change the entry points are extracted with `is_installable: True` and no warnings or errors. `pytest tests/` and pre-commit are green.

One thing worth flagging: `install-check` only runs when `plugins.yaml` changes, so this PR does not exercise the code it fixes. The quickest confirmation is to re-run the checks on [#373](https://github.com/aiidateam/aiida-registry/pull/373) or [#375](https://github.com/aiidateam/aiida-registry/pull/375) once this is merged.

<details>
<summary>Reproducing the permission failure directly</summary>

```console
$ docker run -d --rm -v "$PWD:/tmp/scripts:rw" ghcr.io/aiidateam/aiida-core-with-services:latest tail -f /dev/null
$ docker exec -u aiida -w /tmp/scripts <cid> python -c "open('result.json', 'w')"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
PermissionError: [Errno 13] Permission denied: 'result.json'
```

with the host directory owned by uid 1001 and the container user being `uid=1000(aiida) gid=100(users)`.

</details>
