### PR TITLE
Add plugin_info for reserved aiida-eon

### DIFF
--- a/plugins.yaml
+++ b/plugins.yaml
@@ -143,6 +143,7 @@ aiida-eon:
   code_home: https://github.com/HaoZeke/aiida-eon
   entry_point_prefix: eon
   plugin_info: https://raw.githubusercontent.com/HaoZeke/aiida-eon/main/pyproject.toml
+  pip_url: aiida-eon
 aiida-eonclient:
   code_home: https://github.com/HaoZeke/aiida-eonclient
   entry_point_prefix: eonclient

--- a/plugins.yaml
+++ b/plugins.yaml
@@ -142,6 +142,7 @@ aiida-environ:
 aiida-eon:
   code_home: https://github.com/HaoZeke/aiida-eon
   entry_point_prefix: eon
+  plugin_info: https://raw.githubusercontent.com/HaoZeke/aiida-eon/main/pyproject.toml
 aiida-eonclient:
   code_home: https://github.com/HaoZeke/aiida-eonclient
   entry_point_prefix: eonclient


### PR DESCRIPTION
The reserved `aiida-eon` block has no `plugin_info`, so the scanner cannot read the `aiida-core` pin or the `Framework :: AiiDA` classifier (E001 / W002, status stuck at planning).

The package is at https://github.com/HaoZeke/aiida-eon (`main`, 0.2.0). PEP 621 `pyproject.toml` already carries the pin and classifiers. This PR only adds:

```yaml
plugin_info: https://raw.githubusercontent.com/HaoZeke/aiida-eon/main/pyproject.toml
```

`pip_url` is left off on purpose. There is no PyPI wheel yet; adding `pip_url: aiida-eon` now would trip the other E001 (`pip install --pre aiida-eon`). I will add it after `twine upload`.

`aiida-eonclient` stays unused so the prefix stays `eon`.